### PR TITLE
Handle public assets during build

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -56,7 +56,7 @@ jobs:
       - name: Build site (templating only)
         run: python fetch.py
 
-      # ✅ Copy static assets into the published artifact (dist)
+      # ✅ Copy static/public assets into the published artifact (dist)
       - name: Copy static assets into dist
         shell: bash
         run: |
@@ -69,8 +69,15 @@ jobs:
               rm -rf dist/static/* 2>/dev/null || true
               cp -r static/* dist/static/
             fi
+          elif [ -d public ]; then
+            mkdir -p dist
+            if command -v rsync >/dev/null 2>&1; then
+              rsync -av --delete public/ dist/
+            else
+              cp -r public/* dist/
+            fi
           else
-            echo "No ./static directory found; skipping copy" >&2
+            echo "No ./static or ./public directory found; skipping copy" >&2
           fi
 
       # Optional but helpful: avoid Jekyll processing oddities on Pages

--- a/fetch.py
+++ b/fetch.py
@@ -12,11 +12,16 @@ def ensure_dist():
     DIST_DIR.mkdir(parents=True, exist_ok=True)
     # prevent Jekyll processing on GH Pages
     (DIST_DIR / ".nojekyll").write_text("", encoding="utf-8")
-    # copy static assets -> dist/static (so use src="static/…")
+    # copy static assets
     static_src = Path("static")
-    static_dst = DIST_DIR / "static"
     if static_src.exists():
-        shutil.copytree(static_src, static_dst, dirs_exist_ok=True)
+        shutil.copytree(static_src, DIST_DIR / "static", dirs_exist_ok=True)
+        return "static"
+    public_src = Path("public")
+    if public_src.exists():
+        shutil.copytree(public_src, DIST_DIR, dirs_exist_ok=True)
+        return "public"
+    return None
 
 def render_index(site_title: str, feed_url: str, public_url: str, proxy_url: str):
     env = Environment(
@@ -35,13 +40,16 @@ def render_index(site_title: str, feed_url: str, public_url: str, proxy_url: str
     (DIST_DIR / "index.html").write_text(html, encoding="utf-8")
 
 def main():
-    ensure_dist()
+    copied = ensure_dist()
     feed_url   = os.getenv("SUBSTACK_FEED", "https://versesvibez.substack.com/feed")
     public_url = os.getenv("PUBLIC_SUBSTACK_URL", "https://versesvibez.substack.com/")
     proxy_url  = os.getenv("RSS_PROXY_URL", "https://api.rss2json.com/v1/api.json?rss_url=")
     site_title = os.getenv("SITE_TITLE", "torchborne")
     render_index(site_title, feed_url, public_url, proxy_url)
-    print("Wrote dist/index.html and copied static/ → dist/static")
+    msg = "Wrote dist/index.html"
+    if copied:
+        msg += f" and copied {copied}/ → dist/"
+    print(msg)
 
 if __name__ == "__main__":
     main()

--- a/tests/test_fetch.py
+++ b/tests/test_fetch.py
@@ -1,0 +1,27 @@
+import importlib.util
+import sys
+from pathlib import Path
+
+root = Path(__file__).resolve().parents[1]
+spec = importlib.util.spec_from_file_location("fetch", root / "fetch.py")
+fetch = importlib.util.module_from_spec(spec)
+sys.modules["fetch"] = fetch
+spec.loader.exec_module(fetch)
+
+
+def test_public_assets_copied(tmp_path, monkeypatch):
+    # Arrange: create a fake public/static directory with a file
+    public_static = tmp_path / "public" / "static"
+    public_static.mkdir(parents=True)
+    (public_static / "styles.css").write_text("body{}", encoding="utf-8")
+
+    # Use the temporary directory as working directory
+    monkeypatch.chdir(tmp_path)
+    fetch.DIST_DIR = tmp_path / "dist"
+
+    # Act
+    copied = fetch.ensure_dist()
+
+    # Assert: assets were copied from public -> dist/static
+    assert copied == "public"
+    assert (fetch.DIST_DIR / "static" / "styles.css").read_text() == "body{}"


### PR DESCRIPTION
## Summary
- Copy assets from `public/` when `static/` is missing
- Support `public` fallback in deployment workflow
- Add regression test for copying assets

## Testing
- `pytest`
- `python fetch.py`

------
https://chatgpt.com/codex/tasks/task_e_68b82bf3dd30832984f64337d7047fbb