### PR TITLE
Preserve index.html during public asset sync

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -72,7 +72,7 @@ jobs:
           elif [ -d public ]; then
             mkdir -p dist
             if command -v rsync >/dev/null 2>&1; then
-              rsync -av --delete public/ dist/
+              rsync -av --delete --exclude='index.html' public/ dist/
             else
               cp -r public/* dist/
             fi


### PR DESCRIPTION
## Summary
- avoid removing `dist/index.html` when copying `public/` assets in deploy workflow by excluding it from rsync deletion

## Testing
- `pytest`
- `python fetch.py >/tmp/fetch.log && cat /tmp/fetch.log`
- `rsync -av --delete --exclude='index.html' public/ dist/ >/tmp/rsync.log && cat /tmp/rsync.log && ls dist`


------
https://chatgpt.com/codex/tasks/task_e_68b82f122c388329b1d7812b01410215