### PR TITLE
Fix CSS link path in index template

### DIFF
--- a/index.html.j2
+++ b/index.html.j2
@@ -19,9 +19,9 @@
   <link href="https://fonts.googleapis.com/css2?family=Inter:wght@300;400;500;600;700&family=Crimson+Text:ital,wght@0,400;0,600;1,400&family=Playfair+Display:ital,wght@0,400;0,700;1,400&display=swap" rel="stylesheet">
 
   <!-- Styles -->
-  <link rel="preload" as="style" href="{{ STATIC }}styles.css$1">
-  <link id="mainCss" rel="stylesheet" href="{{ STATIC }}styles.css$1">
-  <noscript><link rel="stylesheet" href="{{ STATIC }}styles.css$1"></noscript>
+  <link rel="preload" as="style" href="{{ STATIC }}styles.css">
+  <link id="mainCss" rel="stylesheet" href="{{ STATIC }}styles.css">
+  <noscript><link rel="stylesheet" href="{{ STATIC }}styles.css"></noscript>
 
   <link rel="alternate" type="application/rss+xml" title="{{ site_title or 'Feed' }}" href="{{ feed_url }}" />
   <link rel="icon" href="{{ STATIC }}logo-light.png" />


### PR DESCRIPTION
## Summary
- remove stray `$1` from `styles.css` references in `index.html.j2`

## Testing
- `python -m pytest -q`
- `python fetch.py`
- `curl -I http://localhost:8000/static/styles.css`

------
https://chatgpt.com/codex/tasks/task_e_68b830bed1c08329a922d99b9927e983