### PR TITLE
Use relative static path for subdirectory hosting

### DIFF
--- a/index.html.j2
+++ b/index.html.j2
@@ -1,7 +1,7 @@
 <!doctype html>
 <html lang="en" data-theme="light">
 <head>
-  {% set STATIC = static_base or '/static/' %}
+  {% set STATIC = static_base or 'static/' %}
   {% set STATICPUB = static_public_base or (public_url.rstrip('/') + '/static/') if public_url else STATIC %}
   <meta charset="utf-8" />
   <title>{{ site_title or "Torchborne" }}</title>


### PR DESCRIPTION
## Summary
- use relative path for static assets so the site works from subdirectories

## Testing
- `python fetch.py`
- `pytest`
