### PR TITLE
Use template static path for about modal logo fallback

### DIFF
--- a/index.html.j2
+++ b/index.html.j2
@@ -178,7 +178,7 @@
       <button class="modal-close" id="aboutModalClose" aria-label="Close about">✕</button>
       <div class="modal-header">
         <div class="about-header">
-          <img class="about-avatar" src="{{ STATIC }}avatar.jpg" alt="Torchborne" onerror="this.src='static/logo-light.png'">
+          <img class="about-avatar" src="{{ STATIC }}avatar.jpg" alt="Torchborne" onerror="this.src='{{ STATIC }}logo-light.png'">
           <div class="about-info">
             <h2 id="aboutTitle">About Torchborne</h2>
             <p class="about-tagline">Illuminating poetry, carrying the flame of words ✨</p>


### PR DESCRIPTION
## Summary
- Use Jinja `STATIC` base for About modal avatar fallback to ensure logo path works with custom static roots

## Testing
- `python fetch.py`
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68b832979bcc8329a7834a938077eacd