### PR TITLE
Specify favicon type and size

### DIFF
--- a/index.html.j2
+++ b/index.html.j2
@@ -24,7 +24,7 @@
   <noscript><link rel="stylesheet" href="{{ STATIC }}styles.css"></noscript>
 
   <link rel="alternate" type="application/rss+xml" title="{{ site_title or 'Feed' }}" href="{{ feed_url }}" />
-  <link rel="icon" href="{{ STATIC }}logo-light.png" />
+  <link rel="icon" type="image/png" sizes="64x64" href="{{ STATIC }}logo-light.png">
 
   <!-- Open Graph -->
   <meta property="og:title" content="{{ site_title or 'Torchborne' }}" />


### PR DESCRIPTION
## Summary
- Define favicon as a 64×64 PNG so browsers display it correctly.

## Testing
- `python fetch.py`
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68b83293dad08329b0f4cf5bb9d89cda