### PR TITLE
Remove lazy loading from hero logos

### DIFF
--- a/index.html.j2
+++ b/index.html.j2
@@ -86,8 +86,8 @@
         <div class="hero-content">
           <div class="brand-section">
             <a href="./" class="brand-link">
-              <img src="{{ STATIC }}logo-light.png" alt="Torchborne logo" class="logo-img logo-light" loading="lazy" decoding="async" width="64" height="64" fetchpriority="high" />
-              <img src="{{ STATIC }}logo-dark.png" alt="Torchborne logo" class="logo-img logo-dark" loading="lazy" decoding="async" width="64" height="64" fetchpriority="high" />
+              <img src="{{ STATIC }}logo-light.png" alt="Torchborne logo" class="logo-img logo-light" decoding="async" width="64" height="64" fetchpriority="high" />
+              <img src="{{ STATIC }}logo-dark.png" alt="Torchborne logo" class="logo-img logo-dark" decoding="async" width="64" height="64" fetchpriority="high" />
               <h1 class="brand-name">{{ site_title or "Torchborne" }}</h1>
             </a>
             <div class="hero-tagline" aria-live="polite">where words carry the flame ✨</div>


### PR DESCRIPTION
## Summary
- Display logo images immediately on page load by removing `loading="lazy"` from hero logos.

## Testing
- `python fetch.py`
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68b8328f68d88329ab78a64678a9912d