### PR TITLE
Add SRI to DOMPurify CDN script

### DIFF
--- a/index.html.j2
+++ b/index.html.j2
@@ -224,7 +224,7 @@
   </div>
 
   <!-- DOMPurify for robust sanitization -->
-  <script src="https://cdn.jsdelivr.net/npm/dompurify@3/dist/purify.min.js" crossorigin="anonymous" referrerpolicy="no-referrer"></script>
+  <script src="https://cdn.jsdelivr.net/npm/dompurify@3/dist/purify.min.js" integrity="sha384-OLBgp1GsljhM2TJ+sbHjaiH9txEUvgdDTAzHv2P24donTt6/529l+9Ua0vFImLlb" crossorigin="anonymous" referrerpolicy="no-referrer"></script>
 
   <script>
     // ===== CONFIG =====


### PR DESCRIPTION
## Summary
- add Subresource Integrity to DOMPurify CDN script and maintain no-referrer policy

## Testing
- `pytest -q`
- `python fetch.py`
- ⚠️ `playwright install chromium` (403 Forbidden)


------
https://chatgpt.com/codex/tasks/task_e_68b83e9ac9f48329aa8538453420fdc4