### PR TITLE
Rotate hero tagline over time

### DIFF
--- a/index.html.j2
+++ b/index.html.j2
@@ -759,6 +759,11 @@
       content.init();
       const tag = document.querySelector('.hero-tagline');
       if (tag) tag.textContent = TAGLINES[Math.floor(Math.random() * TAGLINES.length)];
+      let i = 0;
+      setInterval(() => {
+        i = (i + 1) % TAGLINES.length;
+        tag.textContent = TAGLINES[i];
+      }, 5000);
       console.log('✨ Torchborne — ready to inspire');
       
       // Verify CSS actually loaded; if not, show a helpful status


### PR DESCRIPTION
## Summary
- cycle through hero taglines every few seconds using `setInterval`

## Testing
- `pytest -q`
- `python fetch.py`
- `node - <<'NODE'` (verify tagline rotation)


------
https://chatgpt.com/codex/tasks/task_e_68b844150d408329bbb0acdbc3fe31e8