### PR TITLE
feat: add skeleton placeholders

### DIFF
--- a/index.html.j2
+++ b/index.html.j2
@@ -636,6 +636,19 @@
         return el;
       }
 
+      skeleton(){
+        const el = document.createElement('div');
+        el.className = 'card-skeleton';
+        el.innerHTML = `
+          <div class="skeleton-thumb shimmer"></div>
+          <div class="skeleton-content">
+            <div class="skeleton-line shimmer"></div>
+            <div class="skeleton-line shimmer"></div>
+            <div class="skeleton-line shimmer short"></div>
+          </div>`;
+        return el;
+      }
+
       render(list){
         els.grid.hidden = false;
         this.viewList = list;
@@ -677,6 +690,10 @@
         els.grid.setAttribute('aria-busy','true');
         els.status.classList.remove('hidden','error');
         els.status.textContent = "Gathering poems from the digital ether...";
+        els.grid.innerHTML = '';
+        for (let i = 0; i < this.pageSize; i++) {
+          els.grid.appendChild(this.skeleton());
+        }
         const sources = [];
         const worker   = WORKER_BASE ? WORKER_BASE + encodeURIComponent(RSS_URL) : null;
         const publicUrl= PUBLIC_BASE + encodeURIComponent(RSS_URL);
@@ -729,6 +746,7 @@
           }
         }
         this.fail();
+        els.grid.innerHTML = '';
         els.grid.removeAttribute('aria-busy');
       }
 

--- a/public/static/styles.css
+++ b/public/static/styles.css
@@ -167,6 +167,38 @@ a:hover { color: var(--accent-solid); }
 .card-actions a:hover { color: var(--card-accent-solid); }
 .card-actions a:hover::after { width: 100%; }
 
+/* Skeleton placeholder cards */
+.card-skeleton {
+  background: var(--paper);
+  border: 1px solid var(--border);
+  border-radius: 24px;
+  box-shadow: var(--shadow-sm);
+  overflow: hidden;
+}
+.card-skeleton .skeleton-thumb {
+  width: 100%;
+  aspect-ratio: 16/10;
+  background: var(--border);
+}
+.card-skeleton .skeleton-content {
+  padding: 24px;
+}
+.card-skeleton .skeleton-line {
+  height: 14px;
+  margin-bottom: 12px;
+  background: var(--border);
+  border-radius: 4px;
+}
+.card-skeleton .skeleton-line.short {
+  width: 60%;
+}
+.card-skeleton .shimmer {
+  background: var(--border);
+  background-image: linear-gradient(90deg, transparent, rgba(255,255,255,.2), transparent);
+  background-size: 200px 100%;
+  animation: shimmer 2s infinite;
+}
+
 /* ---------- MODALS ---------- */
 .modal { position: fixed; inset: 0; background: rgba(0, 0, 0, 0.6); backdrop-filter: blur(8px); display: none; align-items: center; justify-content: center; padding: 24px; z-index: 1000; opacity: 0; transition: opacity .3s ease; }
 .modal.open { display: flex; opacity: 1; }


### PR DESCRIPTION
## Summary
- add card skeleton styles that reuse shimmer animation
- show skeleton cards while fetching posts
- clear placeholders when posts load or fail

## Testing
- `pytest -q`
- `python fetch.py`


------
https://chatgpt.com/codex/tasks/task_e_68b84541cbf88329ae9a872842667d8d