### PR TITLE
Use relative static path for assets

### DIFF
--- a/index.html.j2
+++ b/index.html.j2
@@ -1,7 +1,7 @@
 <!doctype html>
 <html lang="en" data-theme="light">
 <head>
-  {% set STATIC = static_base or 'static/' %}
+  {% set STATIC = static_base or './static/' %}
   {% set STATICPUB = static_public_base or (public_url.rstrip('/') + '/static/') if public_url else STATIC %}
   <meta charset="utf-8" />
   <title>{{ site_title or "Torchborne" }}</title>


### PR DESCRIPTION
## Summary
- reference static assets with a relative path so they work when served from a subfolder

## Testing
- `python fetch.py`
- `curl -sI http://localhost:8000/dist/index.html | head -n 1`
- `curl -sI http://localhost:8000/dist/static/styles.css | head -n 1`
- `curl -sI http://localhost:8000/dist/static/logo-light.svg | head -n 1`
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68b847f355648329b1dedf4198750126