### PR TITLE
Make skip link visible on focus

### DIFF
--- a/public/static/styles.css
+++ b/public/static/styles.css
@@ -275,6 +275,24 @@ a:hover { color: var(--accent-solid); }
 .hidden { display: none !important; }
 .visually-hidden { position: absolute !important; width: 1px !important; height: 1px !important; padding: 0 !important; margin: -1px !important; overflow: hidden !important; clip: rect(0, 0, 0, 0) !important; white-space: nowrap !important; border: 0 !important; }
 
+#skipLink:focus {
+  position: fixed;
+  top: 12px;
+  left: 12px;
+  width: auto;
+  height: auto;
+  margin: 0;
+  padding: 12px 16px;
+  clip: auto;
+  overflow: visible;
+  white-space: normal;
+  background: var(--accent-solid);
+  color: #fff;
+  border-radius: 8px;
+  box-shadow: var(--shadow-sm);
+  z-index: 1000;
+}
+
 /* ---------- Small extras for polish ---------- */
 #loadMore { display: none; margin: 24px auto 0; }
 .btn:focus-visible, .chip:focus-visible, .linklike:focus-visible { outline: 2px solid var(--accent-solid); outline-offset: 2px; }


### PR DESCRIPTION
## Summary
- allow skip link to display when focused for keyboard navigation

## Testing
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_68b8499b61fc8329b48cc3b0409d1efa