### PR TITLE
Specify favicon type and size

### DIFF
--- a/index.html.j2
+++ b/index.html.j2
@@ -24,7 +24,7 @@
   <noscript><link rel="stylesheet" href="{{ STATIC }}styles.css"></noscript>
 
   <link rel="alternate" type="application/rss+xml" title="{{ site_title or 'Feed' }}" href="{{ feed_url }}" />
-  <link rel="icon" type="image/svg+xml" sizes="64x64" href="{{ STATIC }}logo-light.svg">
+  <link rel="icon" type="image/png" sizes="64x64" href="{{ STATIC }}logo-light.png">
 
   <!-- Open Graph -->
   <meta property="og:title" content="{{ site_title or 'Torchborne' }}" />


### PR DESCRIPTION
## Summary
- Ensure favicon link references PNG file with explicit type and size attributes

## Testing
- `python fetch.py`
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_68b84d1166bc8329b2f30afadb2ddb87