### PR TITLE
Fix modal overlay and add ebook poem preview support

### DIFF
--- a/README.md
+++ b/README.md
@@ -17,3 +17,15 @@ export PUBLIC_SUBSTACK_URL="https://YOUR.substack.com/"
 export RSS_PROXY_URL="https://your-worker.example/?rss_url="  # optional
 python build.py
 cd dist && python -m http.server 8080
+
+# Optional: Featured eBook spotlight
+# export EBOOK_URL="https://your.substack.com/p/your-ebook"
+# export EBOOK_TITLE="Your Poetry eBook"
+# export EBOOK_DESCRIPTION="Short blurb that appears in the featured card"
+# export EBOOK_CTA_TEXT="Read eBook"
+# export EBOOK_NOTE="Optional dedication or note shown with the preview"
+# export EBOOK_PREVIEW_TITLE="Sneak Peek"
+# export EBOOK_PREVIEW_HTML="<p>First line of the poem</p><p>Second line of the poem</p>"
+# export EBOOK_PREVIEW_BUTTON_TEXT="Read sample"
+# export EBOOK_POEM_TITLE="Featured Poem"
+# export EBOOK_POEM_TEXT=$'first line of the poem\nsecond line of the poem'

--- a/fetch.py
+++ b/fetch.py
@@ -23,17 +23,60 @@ def ensure_dist():
         return "public"
     return None
 
+def _env_trim(name: str, default: str = "") -> str:
+    """Return an environment variable with leading/trailing whitespace removed."""
+    value = os.getenv(name)
+    if value is None:
+        return default
+    return value.strip()
+
+
+def _env_multiline(name: str, default: str = "") -> str:
+    """Return an environment variable preserving internal newlines."""
+    value = os.getenv(name)
+    if value is None:
+        return default
+    normalized = value.replace("\r\n", "\n").replace("\r", "\n")
+    return normalized.strip("\n")
+
+
 def render_index(site_title: str, feed_url: str, public_url: str, proxy_url: str):
     env = Environment(
         loader=FileSystemLoader("."),
         autoescape=select_autoescape(["html", "xml"])
     )
     tpl = env.get_template(TEMPLATE_FILE.name)
+    ebook_default_url = ""
+    if public_url:
+        ebook_default_url = public_url.rstrip("/") + "/p/torchborne-poetry-ebook"
+    featured_ebook = {
+        "title": _env_trim("EBOOK_TITLE", "Torchborne Poetry eBook"),
+        "description": _env_trim(
+            "EBOOK_DESCRIPTION",
+            "A lovingly curated digital chapbook—now available on Amazon Kindle.",
+        ),
+        "url": _env_trim("EBOOK_URL", ebook_default_url),
+        "cta_text": _env_trim("EBOOK_CTA_TEXT", "Read eBook"),
+        "note": _env_multiline("EBOOK_NOTE"),
+        "tag": _env_trim("EBOOK_TAG", "Featured"),
+        "cover": _env_trim("EBOOK_COVER"),
+        "pub_date": _env_trim("EBOOK_PUB_DATE"),
+        "meta": _env_trim("EBOOK_META", "Amazon Kindle Edition"),
+        "share_text": _env_trim("EBOOK_SHARE_TEXT", "Share"),
+        "preview_title": _env_trim("EBOOK_PREVIEW_TITLE"),
+        "preview_html": _env_multiline("EBOOK_PREVIEW_HTML"),
+        "preview_button_text": _env_trim("EBOOK_PREVIEW_BUTTON_TEXT"),
+        "poem_title": _env_trim("EBOOK_POEM_TITLE"),
+        "poem_text": _env_multiline("EBOOK_POEM_TEXT"),
+    }
+    if not featured_ebook["url"]:
+        featured_ebook = {}
     html = tpl.render(
         site_title=site_title or "torchborne",
         public_url=public_url,
         feed_url=feed_url,
         rss_proxy_url=(proxy_url or "").rstrip("?&"),
+        featured_ebook=featured_ebook,
         generated_at=datetime.now(timezone.utc),
         items=[]  # client-side populates
     )

--- a/index.html.j2
+++ b/index.html.j2
@@ -102,6 +102,11 @@
             <button id="aboutBtn" class="btn" title="About" aria-haspopup="dialog" aria-controls="aboutModal">
               <span>👋</span> About
             </button>
+            {% if featured_ebook %}
+            <a class="btn" href="{{ featured_ebook.url }}" target="_blank" rel="noopener">
+              <span>📘</span> {{ featured_ebook.cta_text or 'Read eBook' }}
+            </a>
+            {% endif %}
             <a class="btn btn-primary" href="{{ public_url.rstrip('/') + '/subscribe' }}" rel="noopener">
               <span>💌</span> Subscribe
             </a>
@@ -241,6 +246,7 @@
       "https://api.rss2json.com/v1/api.json?"
       + (RSS2JSON_KEY ? ("api_key=" + encodeURIComponent(RSS2JSON_KEY) + "&") : "")
       + "count=" + encodeURIComponent(MAX_ITEMS) + "&rss_url=";
+    const FEATURED_EBOOK = {{ (featured_ebook or {}) | tojson }};
     const TAGLINES = [
       "where words carry the flame ✨",
       "poetry for wandering souls ✍️",
@@ -296,6 +302,14 @@
     const debounce = (fn, ms=200) => {
       let t; return (...args) => { clearTimeout(t); t = setTimeout(() => fn(...args), ms); };
     };
+
+    const escapeHtml = (str='') =>
+      String(str)
+        .replace(/&/g, '&amp;')
+        .replace(/</g, '&lt;')
+        .replace(/>/g, '&gt;')
+        .replace(/"/g, '&quot;')
+        .replace(/'/g, '&#039;');
 
     // Theme
     class ThemeManager {
@@ -447,6 +461,32 @@
           if (n.startsWith('on') || v.startsWith('javascript:')) el.removeAttribute(attr.name);
         });
       });
+      div.querySelectorAll('[style]').forEach(el => {
+        const rawStyle = el.getAttribute('style') || '';
+        const blockedPosition = /position\s*:\s*(?:fixed|sticky|absolute)/i.test(rawStyle);
+        const hasAbsolute = /position\s*:\s*absolute/i.test(rawStyle);
+        const absoluteOverlay = hasAbsolute && /(?:top|right|bottom|left|inset)\s*:/i.test(rawStyle);
+        const cleaned = [];
+        const blockedDirectional = new Set(['top','right','bottom','left','inset']);
+        rawStyle.split(';').forEach(rule => {
+          const trimmed = rule.trim();
+          if (!trimmed) return;
+          const parts = trimmed.split(':');
+          if (parts.length < 2) return;
+          const prop = parts[0].trim();
+          const value = parts.slice(1).join(':').trim();
+          const propLower = prop.toLowerCase();
+          const valueLower = value.toLowerCase();
+          if (propLower === 'position' && /absolute|fixed|sticky/.test(valueLower)) return;
+          if (propLower === 'z-index') return;
+          if (propLower === 'pointer-events' && valueLower !== 'auto') return;
+          if ((blockedPosition || absoluteOverlay) && blockedDirectional.has(propLower)) return;
+          if ((absoluteOverlay || blockedPosition) && (propLower === 'width' || propLower === 'height') && /100%/.test(valueLower)) return;
+          cleaned.push(`${prop}: ${value}`);
+        });
+        if (cleaned.length) el.setAttribute('style', cleaned.join('; '));
+        else el.removeAttribute('style');
+      });
       // Remove substack widgets
       div.querySelectorAll('.subscription-widget, .subscription-widget-wrap-editor, .button-wrapper').forEach(el => el.remove());
       return div.innerHTML;
@@ -492,11 +532,43 @@
         lastFocus?.focus();
       }
       openReading(post, idx){
-        const date = post.pubDate ? new Date(post.pubDate).toLocaleDateString(undefined, { year: 'numeric', month: 'long', day: 'numeric' }) : '';
-        els.modalTitle.textContent = post.title || 'Untitled';
-        els.modalMeta.textContent = date;
+        const isEbook = post.featureType === 'ebook';
+        let meta = '';
+        if (isEbook) {
+          meta = post.feature?.meta || '';
+        } else if (post.pubDate) {
+          meta = new Date(post.pubDate).toLocaleDateString(undefined, { year: 'numeric', month: 'long', day: 'numeric' });
+        }
+        const heading = isEbook
+          ? (post.feature?.modalTitle || post.title || 'Featured eBook')
+          : (post.title || 'Untitled');
+        els.modalTitle.textContent = heading;
+        els.modalMeta.textContent = meta;
         els.modalBody.innerHTML = sanitize(post.content || post.description || '');
         els.modalBody.querySelectorAll('img').forEach(img => { img.loading='lazy'; img.decoding='async'; img.removeAttribute('width'); img.removeAttribute('height'); });
+
+        if (isEbook) {
+          if (post.feature?.note) {
+            const existing = els.modalBody.querySelector('.ebook-note');
+            if (!existing) {
+              const note = document.createElement('p');
+              note.className = 'ebook-note';
+              note.textContent = post.feature.note;
+              els.modalBody.prepend(note);
+            }
+          }
+          const ctaWrap = document.createElement('p');
+          ctaWrap.className = 'ebook-preview-cta';
+          const link = document.createElement('a');
+          link.className = 'btn btn-primary';
+          link.href = post.link;
+          link.target = '_blank';
+          link.rel = 'noopener';
+          const ctaText = (post.feature?.ctaText || 'Read eBook').trim() || 'Read eBook';
+          link.textContent = ctaText;
+          ctaWrap.appendChild(link);
+          els.modalBody.appendChild(ctaWrap);
+        }
 
         lastFocus = document.activeElement;
         els.readingModal.classList.add('open');
@@ -555,6 +627,7 @@
         this.viewList = [];
         this.pageSize = 6; // show 6 posts at a time
         this.shown = 0;
+        this.featured = this.prepareFeatured();
       }
       init(){
         els.search?.addEventListener('input', debounce(() => this.search(), 120));
@@ -562,6 +635,158 @@
         els.randomBtn?.addEventListener('click', () => this.random());
         els.loadMore?.addEventListener('click', () => this.renderNextChunk(false));
         this.load();
+      }
+
+      normalizeUrl(url){
+        if (!url) return '';
+        try {
+          const base = typeof window !== 'undefined' && window.location ? window.location.origin : undefined;
+          const target = base ? new URL(url, base) : new URL(url);
+          const cleanPath = target.pathname.replace(/\/+$/, '');
+          return `${target.protocol}//${target.host.toLowerCase()}${cleanPath}`;
+        } catch {
+          return String(url).trim().replace(/\/+$/, '');
+        }
+      }
+
+      prepareFeatured(){
+        if (!FEATURED_EBOOK || !FEATURED_EBOOK.url) return null;
+        const url = (FEATURED_EBOOK.url || '').trim();
+        if (!url) return null;
+        const desc = (FEATURED_EBOOK.description || '').trim();
+        const note = (FEATURED_EBOOK.note || '').trim();
+        const previewHtml = (FEATURED_EBOOK.preview_html || '').trim();
+        const poemTitle = (FEATURED_EBOOK.poem_title || '').trim();
+        const poemText = (FEATURED_EBOOK.poem_text || '').replace(/\r\n?/g, '\n').trim();
+        const hasPreview = previewHtml.length > 0;
+        const hasPoem = poemText.length > 0;
+        const previewTitle = (FEATURED_EBOOK.preview_title || '').trim();
+        const previewButton = (FEATURED_EBOOK.preview_button_text || '').trim();
+        const ctaRaw = (FEATURED_EBOOK.cta_text || 'Read eBook').trim() || 'Read eBook';
+        const quick = [];
+        if (previewTitle) {
+          quick.push(`<h3 class="ebook-preview-title">${escapeHtml(previewTitle)}</h3>`);
+        }
+        if (hasPreview) {
+          quick.push(`<div class="ebook-preview">${previewHtml}</div>`);
+        }
+        if (hasPoem) {
+          quick.push(this.poemHtml(poemTitle, poemText));
+        }
+        if (!hasPreview && !hasPoem) {
+          if (desc) quick.push(`<p>${escapeHtml(desc)}</p>`);
+          if (note) quick.push(`<p class="ebook-note">${escapeHtml(note)}</p>`);
+        }
+        if (!quick.length) quick.push('<p class="ebook-note">Preview coming soon.</p>');
+        const normalized = this.normalizeUrl(url);
+        const summary = desc
+          || (hasPreview ? this.textOnly(previewHtml) : '')
+          || (hasPoem ? this.poemSummary(poemText) : '')
+          || note;
+        return {
+          url,
+          normalized,
+          title: FEATURED_EBOOK.title || 'Poetry eBook',
+          pubDate: (FEATURED_EBOOK.pub_date || '').trim(),
+          summary,
+          quickHtml: quick.join('\n'),
+          feature: {
+            tag: (FEATURED_EBOOK.tag || 'Featured').trim() || 'Featured',
+            ctaText: ctaRaw,
+            cover: (FEATURED_EBOOK.cover || '').trim(),
+            meta: (FEATURED_EBOOK.meta || '').trim(),
+            shareText: (FEATURED_EBOOK.share_text || 'Share').trim() || 'Share',
+            modalTitle: previewTitle || FEATURED_EBOOK.title || 'Poetry eBook',
+            note,
+            hasPreview,
+            hasPoem,
+            poemTitle,
+            poemText,
+            quickLabel: previewButton || (hasPreview ? 'Read sample' : hasPoem ? 'Read poem' : 'Preview'),
+            description: desc,
+          },
+        };
+      }
+
+      poemSummary(text=''){
+        const lines = text.split(/\n+/).map(line => line.trim()).filter(Boolean);
+        if (!lines.length) return '';
+        const snippet = lines.slice(0, 3).join(' / ');
+        return snippet.length > 280 ? snippet.slice(0, 277) + '…' : snippet;
+      }
+
+      poemHtml(title='', text=''){
+        if (!text) return '';
+        const normalized = text.split(/\n/);
+        const stanzas = [];
+        let current = [];
+        for (const rawLine of normalized) {
+          const line = rawLine.replace(/\s+$/,'');
+          if (!line.trim()) {
+            if (current.length) { stanzas.push(current); current = []; }
+            continue;
+          }
+          current.push(line);
+        }
+        if (current.length) stanzas.push(current);
+        const renderLine = (line) => {
+          const escaped = escapeHtml(line);
+          const leading = escaped.match(/^[\s\u00a0]+/);
+          if (!leading) return escaped;
+          const prefix = leading[0]
+            .replace(/ /g, '&nbsp;')
+            .replace(/\t/g, '&nbsp;&nbsp;&nbsp;&nbsp;');
+          return prefix + escaped.slice(leading[0].length);
+        };
+        const body = stanzas.length
+          ? stanzas.map(lines => `<p>${lines.map(renderLine).join('<br>')}</p>`).join('')
+          : `<p>${renderLine(text)}</p>`;
+        const heading = title ? `<h3 class="ebook-poem-title">${escapeHtml(title)}</h3>` : '';
+        return `<div class="ebook-poem">${heading}${body}</div>`;
+      }
+
+      featuredExtras(){
+        if (!this.featured) return [];
+        return [{
+          title: this.featured.title,
+          link: this.featured.url,
+          pubDate: this.featured.pubDate || '',
+          content: this.featured.quickHtml,
+          description: this.featured.summary || this.featured.feature.description || '',
+          featureType: 'ebook',
+          feature: { ...this.featured.feature },
+        }];
+      }
+
+      decorateFeatured(list){
+        if (!this.featured) return { posts: [...list], extras: [], matched: false };
+        const target = this.featured.normalized;
+        let matchedIndex = -1;
+        const decorated = list.map((item, idx) => {
+          if (matchedIndex >= 0) return item;
+          const linkNorm = this.normalizeUrl(item.link || item.guid || '');
+          if (linkNorm && target && linkNorm === target) {
+            matchedIndex = idx;
+            const copy = { ...item };
+            copy.featureType = 'ebook';
+            copy.feature = {
+              ...this.featured.feature,
+              hasPreview: false,
+              hasPoem: false,
+              poemText: '',
+              quickLabel: 'Read poem'
+            };
+            if (!copy.title) copy.title = this.featured.title;
+            if (!copy.pubDate && this.featured.pubDate) copy.pubDate = this.featured.pubDate;
+            if (!copy.description && this.featured.summary) copy.description = this.featured.summary;
+            return copy;
+          }
+          return item;
+        });
+        if (matchedIndex >= 0) {
+          return { posts: decorated, extras: [], matched: true };
+        }
+        return { posts: decorated, extras: this.featuredExtras(), matched: false };
       }
 
       textOnly(html){
@@ -590,53 +815,101 @@
       }
 
       card(post, idx){
+        const isEbook = post.featureType === 'ebook';
         const date = post.pubDate ? new Date(post.pubDate) : null;
-        const dateStr = date ? date.toLocaleDateString(undefined,{year:'numeric',month:'short',day:'numeric'}) : '';
         const html = post.content || post.description || '';
         const txt = this.textOnly(html);
-        const img = this.firstImage(html);
-        const summary = txt.length > 280 ? txt.slice(0,280) + '…' : txt;
-        const rt = txt ? this.readTime(txt) : '';
-        const tags = this.vibes(post.title);
+        const hasPreview = isEbook ? Boolean(post.feature?.hasPreview) : false;
+        const hasPoem = isEbook ? Boolean(post.feature?.hasPoem) : false;
+        const poemTitle = isEbook ? (post.feature?.poemTitle || '').trim() : '';
+        const poemText = isEbook ? (post.feature?.poemText || '').trim() : '';
+        const poemSnippet = hasPoem ? this.poemSummary(poemText) : '';
+        const noteText = isEbook ? (post.feature?.note || '').trim() : '';
+        const summary = isEbook
+          ? ((post.feature?.description || '').trim()
+              || (post.description || '').trim()
+              || (poemSnippet ? (poemTitle ? `${poemTitle} — ${poemSnippet}` : poemSnippet) : '')
+              || (hasPreview ? this.textOnly(post.content || '') : '')
+              || noteText
+              || txt)
+          : (txt.length > 280 ? txt.slice(0,280) + '…' : txt);
+        const img = isEbook ? null : this.firstImage(html);
+        const rt = !isEbook && txt ? this.readTime(txt) : '';
+        const tags = isEbook ? [] : this.vibes(post.title);
+        const quickLabel = isEbook
+          ? (post.feature?.quickLabel || (hasPoem ? 'Read poem' : (hasPreview ? 'Read sample' : 'Preview')))
+          : 'Quick read';
 
         const el = document.createElement('article');
         const palettes = ['accent','accent-2','accent-3'];
         const accentClass = palettes[idx % palettes.length];
-        el.className = `card ${accentClass}`;
+        el.className = `card ${isEbook ? 'ebook-card accent-3' : accentClass}`;
         el.style.transitionDelay = `${Math.min(idx,15)*100}ms`;
-        el.setAttribute('aria-label', post.title || 'Poem');
+        el.setAttribute('aria-label', post.title || (isEbook ? 'Featured eBook' : 'Poem'));
 
-        el.innerHTML = `
-          ${img ? `<div class="card-thumb"><img loading="lazy" decoding="async" src="${img}" alt="" /></div>` : `<div class="card-thumb" aria-hidden="true"></div>`}
-          <div class="card-content">
-            <h2 class="card-title"><a href="${post.link}" target="_blank" rel="noopener">${post.title || 'Untitled'}</a></h2>
-            <div class="card-meta">
-              ${dateStr ? `<span>📅 ${dateStr}</span>` : '' }
-              ${rt ? `<span>⏱️ ${rt}</span>` : '' }
+        if (isEbook) {
+          const tag = post.feature?.tag || 'Featured';
+          const ctaText = post.feature?.ctaText || 'Read eBook';
+          const shareText = post.feature?.shareText || 'Share';
+          const meta = post.feature?.meta || '';
+          const cover = post.feature?.cover || '';
+          const hasPreview = Boolean(post.feature?.hasPreview);
+          const hasPoem = Boolean(post.feature?.hasPoem);
+          el.innerHTML = `
+            <div class="card-content ebook">
+              <div class="ebook-flag">${escapeHtml(tag)}</div>
+              <div class="ebook-layout">
+                <div class="ebook-cover${cover ? '' : ' placeholder'}">
+                  ${cover ? `<img loading="lazy" decoding="async" src="${cover}" alt="" />` : '<span aria-hidden="true">📘</span>'}
+                </div>
+                <div class="ebook-details">
+                  <h2 class="card-title"><a href="${post.link}" target="_blank" rel="noopener">${escapeHtml(post.title || 'Poetry eBook')}</a></h2>
+                  ${meta ? `<div class="card-meta single">${escapeHtml(meta)}</div>` : ''}
+                  <div class="card-summary">${escapeHtml(summary)}</div>
+                  ${noteText && (hasPreview || hasPoem) ? `<div class="ebook-note">${escapeHtml(noteText)}</div>` : ''}
+                  <div class="card-actions ebook-actions">
+                    <a class="btn btn-primary" href="${post.link}" target="_blank" rel="noopener">${escapeHtml(ctaText)}</a>
+                    <button type="button" class="linklike" data-quick-read="1" aria-controls="readingModal">${escapeHtml(quickLabel)}</button>
+                    <a href="#" data-share="${encodeURIComponent(post.link)}">${escapeHtml(shareText)}</a>
+                  </div>
+                </div>
+              </div>
             </div>
-            <div class="card-summary">${summary}</div>
-            ${tags.length ? `<div class="card-badges">${tags.map(v=>`<span class="badge">${v}</span>`).join('')}</div>` : ''}
-            <div class="card-actions">
-              <a href="${post.link}" target="_blank" rel="noopener">Read on Substack →</a>
-              <button type="button" class="linklike" data-quick-read="1" aria-controls="readingModal">Quick read</button>
-              <a href="#" data-share="${encodeURIComponent(post.link)}">Share</a>
+          `;
+        } else {
+          const dateStr = date ? date.toLocaleDateString(undefined,{year:'numeric',month:'short',day:'numeric'}) : '';
+          el.innerHTML = `
+            ${img ? `<div class="card-thumb"><img loading="lazy" decoding="async" src="${img}" alt="" /></div>` : `<div class="card-thumb" aria-hidden="true"></div>`}
+            <div class="card-content">
+              <h2 class="card-title"><a href="${post.link}" target="_blank" rel="noopener">${escapeHtml(post.title || 'Untitled')}</a></h2>
+              <div class="card-meta">
+                ${dateStr ? `<span>📅 ${escapeHtml(dateStr)}</span>` : '' }
+                ${rt ? `<span>⏱️ ${escapeHtml(rt)}</span>` : '' }
+              </div>
+              <div class="card-summary">${escapeHtml(summary)}</div>
+              ${tags.length ? `<div class="card-badges">${tags.map(v=>`<span class="badge">${escapeHtml(v)}</span>`).join('')}</div>` : ''}
+              <div class="card-actions">
+                <a href="${post.link}" target="_blank" rel="noopener">Read on Substack →</a>
+                <button type="button" class="linklike" data-quick-read="1" aria-controls="readingModal">Quick read</button>
+                <a href="#" data-share="${encodeURIComponent(post.link)}">Share</a>
+              </div>
             </div>
-          </div>
-        `;
+          `;
+        }
 
         // events
         el.querySelector('[data-quick-read]')?.addEventListener('click', e => { e.preventDefault(); modal.openReading(post, idx); });
         const share = el.querySelector('[data-share]');
         share?.addEventListener('click', async e => {
           e.preventDefault();
-          const url = post.link, title = post.title || 'Poem from Torchborne';
+          const url = post.link, title = post.title || (isEbook ? 'Torchborne Poetry eBook' : 'Poem from Torchborne');
           try {
             if (navigator.share) await navigator.share({ title, url });
             else { await navigator.clipboard.writeText(url); const t = share.textContent; share.textContent='Copied ✓'; setTimeout(()=> share.textContent=t, 1500); }
           } catch {}
         });
 
-        const im = el.querySelector('.card-thumb img');
+        const im = el.querySelector('.card-thumb img, .ebook-cover img');
         if (im) { if (im.complete) im.setAttribute('data-loaded','1'); else im.addEventListener('load', () => im.setAttribute('data-loaded','1')); }
         return el;
       }
@@ -722,11 +995,23 @@
               return Boolean(title || text);
             });
 
+            const decorated = this.decorateFeatured(valid);
+            const extras = decorated.extras;
+            const withFeature = decorated.posts;
+
             if (valid.length) {
               // sort newest → oldest so Load older reveals older poems
-              valid.sort((a,b) => new Date(b.pubDate || b.pubdate || 0) - new Date(a.pubDate || a.pubdate || 0));
-              posts = valid;
-              const newest = valid
+              withFeature.sort((a,b) => new Date(b.pubDate || b.pubdate || 0) - new Date(a.pubDate || a.pubdate || 0));
+              if (decorated.matched) {
+                const idxFeat = withFeature.findIndex(p => p.featureType === 'ebook');
+                if (idxFeat > 0) {
+                  const [feat] = withFeature.splice(idxFeat, 1);
+                  withFeature.unshift(feat);
+                }
+              }
+              const combined = extras.concat(withFeature);
+              posts = combined;
+              const newest = withFeature
                 .map(v => new Date(v.pubDate || v.pubdate || 0).getTime())
                 .filter(n => !isNaN(n))
                 .sort((a,b)=>b-a)[0];
@@ -736,13 +1021,23 @@
               } else {
                 els.status.textContent = "";
               }
-              this.render(valid);
+              this.render(combined);
               els.grid.removeAttribute('aria-busy');
               return;
             } else if (raw.length) {
-              posts = raw;
+              const fallbackDecorated = this.decorateFeatured(raw);
+              const orderedFallback = [...fallbackDecorated.posts];
+              if (fallbackDecorated.matched) {
+                const idxFeat = orderedFallback.findIndex(p => p.featureType === 'ebook');
+                if (idxFeat > 0) {
+                  const [feat] = orderedFallback.splice(idxFeat, 1);
+                  orderedFallback.unshift(feat);
+                }
+              }
+              const combined = fallbackDecorated.extras.concat(orderedFallback);
+              posts = combined;
               els.status.textContent = "";
-              this.render(raw);
+              this.render(combined);
               els.grid.removeAttribute('aria-busy');
               return;
             }
@@ -751,7 +1046,14 @@
           }
         }
         this.fail();
-        els.grid.innerHTML = '';
+        const extras = this.featuredExtras();
+        if (extras.length) {
+          posts = extras;
+          els.grid.innerHTML = '';
+          this.render(extras);
+        } else {
+          els.grid.innerHTML = '';
+        }
         els.grid.removeAttribute('aria-busy');
       }
 

--- a/public/static/styles.css
+++ b/public/static/styles.css
@@ -167,6 +167,118 @@ a:hover { color: var(--accent-solid); }
 .card-actions a:hover { color: var(--card-accent-solid); }
 .card-actions a:hover::after { width: 100%; }
 
+/* Featured eBook card */
+.card.ebook-card {
+  background: linear-gradient(135deg, rgba(14,165,233,0.18) 0%, rgba(14,165,233,0.05) 100%);
+  border: 1px solid rgba(14,165,233,0.35);
+  box-shadow: var(--shadow);
+}
+.card-content.ebook {
+  padding: 32px;
+  display: flex;
+  flex-direction: column;
+  gap: 24px;
+}
+.ebook-flag {
+  display: inline-flex;
+  align-items: center;
+  gap: 8px;
+  padding: 6px 14px;
+  border-radius: 999px;
+  background: var(--accent-3);
+  color: white;
+  font-size: 13px;
+  font-weight: 600;
+  letter-spacing: 0.02em;
+  align-self: flex-start;
+  box-shadow: var(--shadow-sm);
+}
+.ebook-layout {
+  display: flex;
+  gap: 24px;
+  align-items: center;
+  flex-wrap: wrap;
+}
+.ebook-cover {
+  width: 180px;
+  height: 240px;
+  border-radius: 20px;
+  border: 1px solid var(--border);
+  background: var(--paper);
+  box-shadow: var(--shadow-sm);
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  overflow: hidden;
+  color: var(--accent-3-solid);
+  font-size: 48px;
+}
+.ebook-cover img {
+  width: 100%;
+  height: 100%;
+  object-fit: cover;
+}
+.ebook-cover.placeholder {
+  background: rgba(14,165,233,0.1);
+}
+.ebook-details {
+  flex: 1;
+  min-width: 260px;
+  display: flex;
+  flex-direction: column;
+  gap: 16px;
+}
+.ebook-details .card-title a {
+  background: none;
+}
+.ebook-details .card-summary {
+  font-size: 16px;
+  color: var(--ink-soft);
+}
+.ebook-actions {
+  display: flex;
+  gap: 16px;
+  align-items: center;
+  flex-wrap: wrap;
+}
+.ebook-actions .btn-primary {
+  box-shadow: var(--shadow);
+}
+.ebook-actions .btn-primary:hover {
+  transform: translateY(-2px) scale(1.01);
+}
+.ebook-details .ebook-note {
+  font-family: 'Crimson Text', serif;
+  font-size: 14px;
+  color: var(--muted);
+  font-style: italic;
+  white-space: pre-line;
+}
+.ebook-actions a[data-share] {
+  color: var(--muted);
+}
+.ebook-actions a[data-share]:hover {
+  color: var(--accent-3-solid);
+}
+.card-meta.single {
+  display: inline-flex;
+  align-items: center;
+  gap: 8px;
+  font-weight: 600;
+}
+
+@media (max-width: 640px) {
+  .ebook-layout {
+    flex-direction: column;
+    align-items: flex-start;
+  }
+  .ebook-cover {
+    width: 100%;
+    height: auto;
+    min-height: 200px;
+  }
+}
+
 /* Skeleton placeholder cards */
 .card-skeleton {
   background: var(--paper);
@@ -202,15 +314,76 @@ a:hover { color: var(--accent-solid); }
 /* ---------- MODALS ---------- */
 .modal { position: fixed; inset: 0; background: rgba(0, 0, 0, 0.6); backdrop-filter: blur(8px); display: none; align-items: center; justify-content: center; padding: 24px; z-index: 1000; opacity: 0; transition: opacity .3s ease; }
 .modal.open { display: flex; opacity: 1; }
-.modal-content { max-width: 900px; max-height: 85vh; width: 100%; background: var(--paper); backdrop-filter: blur(20px); border: 1px solid var(--border); border-radius: 24px; box-shadow: var(--shadow-lg); overflow: hidden; transform: scale(.9) translateY(20px); transition: transform .3s cubic-bezier(.4,0,.2,1); }
+.modal-content { max-width: 900px; max-height: 85vh; width: 100%; background: var(--paper); backdrop-filter: blur(20px); border: 1px solid var(--border); border-radius: 24px; box-shadow: var(--shadow-lg); overflow: hidden; transform: scale(.9) translateY(20px); transition: transform .3s cubic-bezier(.4,0,.2,1); position: relative; isolation: isolate; }
 .modal.open .modal-content { transform: scale(1) translateY(0); }
 .modal-header { padding: 32px 32px 0; position: relative; }
-.modal-close { position: absolute; top: 20px; right: 20px; width: 40px; height: 40px; border: 1px solid var(--border); border-radius: 50%; background: var(--paper); color: var(--muted); cursor: pointer; display: flex; align-items: center; justify-content: center; font-size: 18px; transition: all .3s ease; }
+.modal-close { position: absolute; top: 20px; right: 20px; width: 40px; height: 40px; border: 1px solid var(--border); border-radius: 50%; background: var(--paper); color: var(--muted); cursor: pointer; display: flex; align-items: center; justify-content: center; font-size: 18px; transition: all .3s ease; z-index: 40; pointer-events: auto; box-shadow: var(--shadow-sm); }
 .modal-close:hover { background: var(--accent-solid); color: white; transform: scale(1.1); }
 .modal-title { font-family: 'Playfair Display', serif; font-size: clamp(1.5rem, 3vw, 2rem); font-weight: 400; margin-bottom: 12px; color: var(--ink); line-height: 1.3; }
 .modal-meta { color: var(--muted); font-size: 14px; margin-bottom: 16px; font-weight: 500; }
 .modal-actions { display: flex; gap: 8px; margin-bottom: 8px; }
 .modal-body { padding: 0 32px 32px; font-size: 17px; line-height: 1.8; color: var(--ink-soft); max-height: 60vh; overflow-y: auto; font-family: 'Crimson Text', serif; }
+.modal-body .ebook-note {
+  margin-bottom: 16px;
+  color: var(--muted);
+  font-style: italic;
+  white-space: pre-line;
+}
+.modal-body .ebook-preview-title {
+  font-family: 'Playfair Display', serif;
+  font-weight: 400;
+  font-size: clamp(1.1rem, 2.4vw, 1.35rem);
+  margin-bottom: 12px;
+  color: var(--ink);
+}
+.modal-body .ebook-preview {
+  margin-bottom: 24px;
+  font-family: 'Crimson Text', serif;
+  line-height: 1.9;
+}
+.modal-body .ebook-preview p,
+.modal-body .ebook-preview div {
+  margin-bottom: 1rem;
+}
+.modal-body .ebook-preview pre {
+  white-space: pre-wrap;
+  margin-bottom: 1rem;
+}
+.modal-body .ebook-preview-cta {
+  margin-top: 28px;
+  display: flex;
+  align-items: center;
+  gap: 16px;
+}
+.modal-body .ebook-preview-cta .btn-primary {
+  box-shadow: var(--shadow);
+}
+.modal-body .ebook-preview-cta .btn-primary:hover {
+  transform: translateY(-2px) scale(1.01);
+}
+.modal-body .ebook-poem {
+  margin-bottom: 24px;
+  font-family: 'Crimson Text', serif;
+  font-size: 18px;
+  line-height: 1.9;
+  color: var(--ink);
+}
+.modal-body .ebook-poem-title {
+  font-family: 'Playfair Display', serif;
+  font-weight: 400;
+  font-size: clamp(1.05rem, 2.2vw, 1.3rem);
+  margin-bottom: 12px;
+  color: var(--ink);
+}
+.modal-body .ebook-poem p {
+  margin: 0 0 1rem;
+}
+.modal-body .ebook-poem p:last-child {
+  margin-bottom: 0;
+}
+.modal-body .ebook-poem br {
+  content: "";
+}
 .modal-body img{ max-width: 100%; height: auto; }
 .modal-body::-webkit-scrollbar { width: 6px; }
 .modal-body::-webkit-scrollbar-track { background: var(--border-soft); border-radius: 3px; }


### PR DESCRIPTION
## Summary
- block risky absolute positioning in sanitized content and lift the modal close control so Substack overlays can no longer trap it
- allow authors to provide an ebook poem title/text preview that feeds the featured card and modal, including new quick-read defaults
- document the new environment knobs for poem previews and reuse the data when a Substack entry already matches the featured ebook

## Testing
- pytest

------
https://chatgpt.com/codex/tasks/task_e_68cb06c6f7708329ae4ed495d68914cd