### PR TITLE
Preserve featured poem indentation and add coverage

### DIFF
--- a/fetch.py
+++ b/fetch.py
@@ -45,7 +45,15 @@ def render_index(site_title: str, feed_url: str, public_url: str, proxy_url: str
         "title": _env_trim("EBOOK_TITLE", "Torchborne Poetry eBook"),
         "description": _env_trim(
             "EBOOK_DESCRIPTION",
-
+            "A lovingly curated selection of Torchborne poems."
+        ),
+        "url": _env_trim("EBOOK_URL", ebook_default_url),
+        "cover": _env_trim("EBOOK_COVER", ""),
+        "tag": _env_trim("EBOOK_TAG", "Featured"),
+        "meta": _env_trim("EBOOK_META", "Poetry eBook"),
+        "note": _env_trim("EBOOK_NOTE", ""),
+        "ctaText": _env_trim("EBOOK_CTA_TEXT", "Read eBook"),
+        "shareText": _env_trim("EBOOK_SHARE_TEXT", "Share eBook"),
     }
     if not featured_ebook["url"]:
         featured_ebook = {}

--- a/index.html.j2
+++ b/index.html.j2
@@ -628,6 +628,158 @@
         this.load();
       }
 
+      prepareFeatured(){
+        const curated = [
+          {
+            slug: 'embers-of-dawn',
+            title: 'Embers of Dawn',
+            summary: 'A sunrise prayer stitched from soft embers.',
+            tags: ['poem', 'dawn'],
+            link: 'https://versesvibez.substack.com/p/embers-of-dawn',
+            poem: `
+  hush the dark
+    we gather tinder breaths
+and open windows toward the east
+
+    the first light leans in
+  mapping gold across tired knuckles
+`
+          },
+          {
+            slug: 'cartography-of-rest',
+            title: 'Cartography of Rest',
+            summary: 'Tracing the map back to tenderness and home.',
+            tags: ['poem', 'rest'],
+            link: 'https://versesvibez.substack.com/p/cartography-of-rest',
+            poem: `
+we draw the curtains
+and inventory the quiet
+
+  cushions become coordinates
+  for the map back home
+`
+          },
+          {
+            slug: 'blueprint-for-a-firefly-night',
+            title: 'Blueprint for a Firefly Night',
+            summary: 'Instructions for bottling a summer glow.',
+            tags: ['poem', 'night'],
+            link: 'https://versesvibez.substack.com/p/blueprint-for-a-firefly-night',
+            poem: `
+\tmake a sky out of mason jars
+line them on the porch
+
+
+  leave a stanza empty
+
+    so the fireflies can rest
+`
+          }
+        ];
+
+        const stripEdgeNewlines = (poem = '') =>
+          String(poem || '').replace(/^[\r\n]+/, '').replace(/[\r\n]+$/, '');
+
+        const renderLine = (line='') => {
+          const match = line.match(/^[ \t]+/);
+          let prefix = '';
+          let rest = line;
+          if (match) {
+            prefix = match[0]
+              .replace(/ /g, '&nbsp;')
+              .replace(/\t/g, '&nbsp;&nbsp;&nbsp;&nbsp;');
+            rest = line.slice(match[0].length);
+          }
+          return prefix + escapeHtml(rest);
+        };
+
+        const poemHtml = (poem='') => {
+          const normalized = stripEdgeNewlines(poem)
+            .replace(/\r\n/g, '\n')
+            .replace(/\r/g, '\n');
+          if (!normalized) return '';
+
+          const lines = normalized.split('\n');
+          const paragraphs = [];
+          let current = [];
+
+          const pushCurrent = () => {
+            paragraphs.push(current);
+            current = [];
+          };
+
+          for (const raw of lines) {
+            if (/^[ \t]*$/.test(raw)) {
+              if (current.length) {
+                pushCurrent();
+              } else {
+                paragraphs.push([]);
+              }
+              continue;
+            }
+            current.push(raw);
+          }
+          if (current.length) pushCurrent();
+
+          if (!paragraphs.length) return '';
+
+          return paragraphs
+            .map(linesArr => {
+              if (!linesArr.length) return '<p><br></p>';
+              const htmlLines = linesArr.map(renderLine).join('<br>');
+              return `<p>${htmlLines}</p>`;
+            })
+            .join('');
+        };
+
+        const poems = curated.map(item => {
+          const html = `<div class="ebook-poem"><h3 class="ebook-poem-title">${escapeHtml(item.title)}</h3>${poemHtml(item.poem)}</div>`;
+          return {
+            ...item,
+            html
+          };
+        });
+
+        const extras = [];
+        if (FEATURED_EBOOK?.url) {
+          const summary = (FEATURED_EBOOK.description || '').trim()
+            || 'Preview selections from the Torchborne poetry eBook.';
+          const preview = poems.map(p => p.html).join('');
+          extras.push({
+            featureType: 'ebook',
+            title: FEATURED_EBOOK.title || 'Torchborne Poetry eBook',
+            link: FEATURED_EBOOK.url,
+            description: summary,
+            content: `<div class="ebook-preview">${preview}</div>`,
+            feature: {
+              tag: FEATURED_EBOOK.tag || 'Featured',
+              meta: FEATURED_EBOOK.meta || '',
+              summary,
+              cover: FEATURED_EBOOK.cover || '',
+              shareText: FEATURED_EBOOK.shareText || 'Share eBook',
+              note: FEATURED_EBOOK.note || '',
+              ctaText: (FEATURED_EBOOK.ctaText || 'Read eBook').trim() || 'Read eBook'
+            }
+          });
+        }
+
+        extras.push(...poems.map(poem => ({
+          featureType: 'poem',
+          title: poem.title,
+          link: poem.link,
+          description: poem.summary,
+          content: poem.html,
+          tags: Array.isArray(poem.tags) ? poem.tags : [],
+          feature: { tags: Array.isArray(poem.tags) ? poem.tags : [] }
+        })));
+
+        return { poems, extras, poemHtml };
+      }
+
+      featuredExtras(){
+        return Array.isArray(this.featured?.extras) ? this.featured.extras : [];
+      }
+
       }
 
       textOnly(html){

--- a/tests/test_prepare_featured.py
+++ b/tests/test_prepare_featured.py
@@ -1,0 +1,64 @@
+import json
+import subprocess
+from pathlib import Path
+
+
+ROOT = Path(__file__).resolve().parents[1]
+
+
+def _prepare_featured_source() -> str:
+    template = (ROOT / "index.html.j2").read_text(encoding="utf-8")
+    marker = "prepareFeatured(){"
+    start = template.index(marker)
+    idx = start + len(marker)
+    depth = 1
+    while depth and idx < len(template):
+        char = template[idx]
+        if char == "{":
+            depth += 1
+        elif char == "}":
+            depth -= 1
+        idx += 1
+    method = template[start:idx]
+    return "function " + method
+
+
+def render_poem_html(poem: str) -> str:
+    method_src = _prepare_featured_source()
+    script = f"""
+const escapeHtml = (str = '') => String(str)
+  .replace(/&/g, '&amp;')
+  .replace(/</g, '&lt;')
+  .replace(/>/g, '&gt;')
+  .replace(/"/g, '&quot;')
+  .replace(/'/g, '&#039;');
+const FEATURED_EBOOK = {{}};
+{method_src}
+const featured = prepareFeatured();
+const html = featured.poemHtml({json.dumps(poem)});
+console.log(JSON.stringify({{ html }}));
+"""
+    result = subprocess.run(
+        ["node", "-e", script],
+        capture_output=True,
+        check=True,
+        text=True,
+    )
+    return json.loads(result.stdout)["html"]
+
+
+def test_poem_html_preserves_indentation():
+    poem = "\n  Leading spark\n\tTabbed echo\nStill light\n"
+    html = render_poem_html(poem)
+    assert "&nbsp;&nbsp;Leading spark" in html
+    assert "&nbsp;&nbsp;&nbsp;&nbsp;Tabbed echo" in html
+    assert "Still light" in html
+
+
+def test_poem_html_handles_blank_stanza_and_indent():
+    poem = "\nFirst lantern\n\n\nSecond lantern\n  lingering glow\n"
+    html = render_poem_html(poem)
+    assert "<p>First lantern</p>" in html
+    assert "<p><br></p>" in html
+    assert "Second lantern" in html
+    assert "&nbsp;&nbsp;lingering glow" in html


### PR DESCRIPTION
## Summary
- add a ContentManager.prepareFeatured implementation that keeps curated poem metadata, only strips leading/trailing newlines, and renders stanza HTML while preserving indentation
- expose featured extras, enrich default eBook metadata, and reuse the generated previews for fallback content
- add pytest + Node coverage that exercises poemHtml with indented openings and blank-stanza poems

## Testing
- pytest

------
https://chatgpt.com/codex/tasks/task_e_68cb20f384348329b5c34dc28784c161