### PR TITLE
Preserve indentation in featured poems

### DIFF
--- a/index.html.j2
+++ b/index.html.j2
@@ -677,8 +677,12 @@ line them on the porch
           }
         ];
 
-        const stripEdgeNewlines = (poem = '') =>
-          String(poem || '').replace(/^[\r\n]+/, '').replace(/[\r\n]+$/, '');
+        const stripEdgeNewlines = (poem = '') => {
+          const poemText = poem == null ? '' : String(poem);
+          return poemText
+            .replace(/^(?:\r\n|\r|\n)+/, '')
+            .replace(/(?:\r\n|\r|\n)+$/, '');
+        };
 
         const renderLine = (line='') => {
           const match = line.match(/^[ \t]+/);

--- a/tests/test_prepare_featured.py
+++ b/tests/test_prepare_featured.py
@@ -62,3 +62,15 @@ def test_poem_html_handles_blank_stanza_and_indent():
     assert "<p><br></p>" in html
     assert "Second lantern" in html
     assert "&nbsp;&nbsp;lingering glow" in html
+
+
+def test_poem_html_starts_with_indentation_without_padding_newline():
+    poem = "  Kindling path\nEmber follows\n"
+    html = render_poem_html(poem)
+    assert html.startswith("<p>&nbsp;&nbsp;Kindling path<br>Ember follows</p>")
+
+
+def test_poem_html_leading_blank_stanza_with_indentation():
+    poem = "\n  \nLighthouse hum\n"
+    html = render_poem_html(poem)
+    assert html.startswith("<p><br></p><p>Lighthouse hum</p>")


### PR DESCRIPTION
## Summary
- trim only leading/trailing newline padding when normalizing curated featured poems so their indentation survives
- add regression tests around poemHtml for leading indentation and blank opening stanzas

## Testing
- pytest

------
https://chatgpt.com/codex/tasks/task_e_68cb281754608329b8c00d624f6746de