### PR TITLE
Improve server-rendered posts ordering

### DIFF
--- a/index.html
+++ b/index.html
@@ -264,7 +264,7 @@
       "verses that glow in the dark 🌙"
     ];
     const SUBSTACK_BASE = "https://versesvibez.substack.com";
-    const STATIC_DATA_URL = '/data/posts.json';
+    const STATIC_DATA_URL = './data/posts.json';
 
     function normalizeBase(base) {
       if (!base) return "";

--- a/index.html
+++ b/index.html
@@ -1,421 +1,1304 @@
+<!-- AUTO-GENERATED from index.html.j2. Edit the .j2 file. -->
 <!doctype html>
-<html lang="en">
+<html lang="en" data-theme="light">
 <head>
+  
+  
+  
   <meta charset="utf-8" />
+  <title>Torchborne</title>
   <meta name="viewport" content="width=device-width, initial-scale=1" />
-  <title>Torchborne Poems</title>
-  <style>
-    :root {
-      color-scheme: light dark;
-      font-family: "Inter", system-ui, -apple-system, BlinkMacSystemFont, "Segoe UI", sans-serif;
-      line-height: 1.6;
-    }
-    body {
-      margin: 0;
-      background: #f8fafc;
-      color: #0f172a;
-      min-height: 100vh;
-    }
-    header {
-      padding: 2.5rem 1.5rem 1.5rem;
-      text-align: center;
-    }
-    header h1 {
-      margin: 0 0 0.5rem;
-      font-size: clamp(2rem, 3vw + 1rem, 3rem);
-      letter-spacing: -0.02em;
-    }
-    header p {
-      margin: 0;
-      color: #475569;
-      font-size: 1rem;
-    }
-    main {
-      padding: 0 1.5rem 3rem;
-    }
-    .poem-list {
-      list-style: none;
-      display: grid;
-      gap: 1.5rem;
-      padding: 0;
-      margin: 0 auto;
-      max-width: 58rem;
-      grid-template-columns: repeat(auto-fit, minmax(16rem, 1fr));
-    }
-    .poem-card {
-      margin: 0;
-      border: 1px solid rgba(148, 163, 184, 0.25);
-      border-radius: 18px;
-      background: #fff;
-      box-shadow: 0 25px 60px -35px rgba(15, 23, 42, 0.55);
-      transition: transform 180ms ease, box-shadow 180ms ease;
-      overflow: hidden;
-    }
-    .poem-card__trigger {
-      all: unset;
-      cursor: pointer;
-      display: flex;
-      flex-direction: column;
-      gap: 0.5rem;
-      width: 100%;
-      height: 100%;
-      padding: 1.75rem 1.5rem;
-    }
-    .poem-card__trigger strong {
-      font-size: 1.2rem;
-      font-weight: 600;
-      letter-spacing: -0.01em;
-    }
-    .poem-card__trigger span {
-      font-size: 0.95rem;
-      color: #64748b;
-    }
-    .poem-card__excerpt {
-      margin: 0.75rem 0 0;
-      font-size: 0.95rem;
-      color: #475569;
-    }
-    .poem-card__trigger:focus-visible {
-      outline: 3px solid #f59e0b;
-      outline-offset: 4px;
-    }
-    .poem-card:hover {
-      transform: translateY(-4px);
-      box-shadow: 0 35px 70px -40px rgba(15, 23, 42, 0.65);
-    }
-    .backdrop {
-      position: fixed;
-      inset: 0;
-      background: rgba(15, 23, 42, 0.55);
-      backdrop-filter: blur(4px);
-      opacity: 0;
-      visibility: hidden;
-      pointer-events: none;
-      transition: opacity 180ms ease;
-      z-index: 20;
-    }
-    .backdrop.is-visible {
-      opacity: 1;
-      visibility: visible;
-      pointer-events: auto;
-    }
-    .modal {
-      position: fixed;
-      inset: 0;
-      display: flex;
-      align-items: center;
-      justify-content: center;
-      padding: clamp(1.5rem, 4vw, 3.5rem);
-      z-index: 30;
-      opacity: 0;
-      transform: translateY(12px) scale(0.98);
-      pointer-events: none;
-      transition: opacity 180ms ease, transform 180ms ease;
-    }
-    .modal.is-open {
-      opacity: 1;
-      transform: translateY(0) scale(1);
-      pointer-events: auto;
-    }
-    .modal__shell {
-      background: #ffffff;
-      color: inherit;
-      width: min(100%, 44rem);
-      max-height: min(85vh, 720px);
-      border-radius: 20px;
-      box-shadow: 0 40px 80px -45px rgba(15, 23, 42, 0.6);
-      padding: clamp(1.75rem, 3vw, 2.5rem);
-      display: flex;
-      flex-direction: column;
-      position: relative;
-      overflow: hidden;
-    }
-    .modal__header {
-      display: flex;
-      gap: 1rem;
-      align-items: flex-start;
-      padding-right: 3rem;
-    }
-    .modal__heading {
-      margin: 0;
-      font-size: clamp(1.5rem, 2.6vw, 2.25rem);
-      letter-spacing: -0.015em;
-    }
-    .modal__meta {
-      margin: 0.35rem 0 0;
-      color: #64748b;
-      font-size: 0.95rem;
-    }
-    .modal__close {
-      position: absolute;
-      top: 1.25rem;
-      right: 1.25rem;
-      border: none;
-      background: rgba(15, 23, 42, 0.07);
-      color: inherit;
-      width: 2.5rem;
-      height: 2.5rem;
-      border-radius: 999px;
-      font-size: 1.2rem;
-      display: grid;
-      place-items: center;
-      cursor: pointer;
-      transition: background 160ms ease, transform 160ms ease;
-    }
-    .modal__close:hover {
-      background: rgba(15, 23, 42, 0.12);
-      transform: scale(1.05);
-    }
-    .modal__close:focus-visible {
-      outline: 3px solid #f59e0b;
-      outline-offset: 3px;
-    }
-    .modal__body {
-      margin-top: 1.5rem;
-      padding-right: 0.25rem;
-      overflow-y: auto;
-      white-space: pre-wrap;
-      font-size: 1.02rem;
-    }
-    [hidden] {
-      display: none !important;
-    }
-    @media (prefers-reduced-motion: reduce) {
-      *, *::before, *::after {
-        animation-duration: 0.01ms !important;
-        animation-iteration-count: 1 !important;
-        transition-duration: 0.01ms !important;
-        scroll-behavior: auto !important;
-      }
-    }
-  </style>
+  <meta name="robots" content="index,follow" />
+  <meta name="description" content="Poetry & musings by Dami." />
+  <meta name="color-scheme" content="light dark" />
+  <meta id="themeColorMeta" name="theme-color" content="#f59e0b" />
+  <link rel="canonical" href="" />
+
+  <!-- Fonts -->
+  <link rel="preconnect" href="https://fonts.googleapis.com" crossorigin>
+  <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
+  <link rel="preconnect" href="https://api.rss2json.com" crossorigin>
+  <link href="https://fonts.googleapis.com/css2?family=Inter:wght@300;400;500;600;700&family=Crimson+Text:ital,wght@0,400;0,600;1,400&family=Playfair+Display:ital,wght@0,400;0,700;1,400&display=swap" rel="stylesheet">
+
+  <!-- Styles -->
+  <link rel="preload" as="style" href="./static/styles.css">
+  <link id="mainCss" rel="stylesheet" href="./static/styles.css">
+  <noscript><link rel="stylesheet" href="./static/styles.css"></noscript>
+
+  <link rel="alternate" type="application/rss+xml" title="Feed" href="https://versesvibez.substack.com/feed" />
+  <link rel="icon" type="image/png" sizes="64x64" href="./static/logo-light.png">
+
+  <!-- Open Graph -->
+  <meta property="og:title" content="Torchborne" />
+  <meta property="og:description" content="Poetry & musings by Dami." />
+  <meta property="og:type" content="website" />
+  <meta property="og:url" content="" />
+  <meta property="og:image" content="./static/logo-light.svg" />
+  <meta property="og:site_name" content="Torchborne" />
+  <meta name="twitter:card" content="summary_large_image">
+  <meta name="twitter:image" content="./static/logo-light.svg" />
+
+  <!-- Structured Data -->
+  <script type="application/ld+json">
+  {
+    "@context":"https://schema.org",
+    "@type":"CollectionPage",
+    "name": "Torchborne",
+    "description":"Poetry & musings by Dami.",
+    "url": ""
+  }
+  </script>
+
+  <!-- Relaxed CSP for this static setup -->
+  <meta http-equiv="Content-Security-Policy" content="
+    default-src 'self';
+    img-src 'self' https: data:;
+    style-src 'self' 'unsafe-inline' https:;
+    font-src https:;
+    script-src 'self' 'unsafe-inline' https://cdn.jsdelivr.net;
+    connect-src 'self' https:;
+    base-uri 'self';
+    form-action 'self';
+    upgrade-insecure-requests
+  ">
 </head>
 <body>
-  <header>
-    <h1>Torchborne Poetry</h1>
-    <p>Curated verses with a quick-read modal for quiet nights.</p>
-  </header>
-  <main>
-    <ul class="poem-list" data-poem-list></ul>
-  </main>
+  <a href="#postsGrid" class="visually-hidden" id="skipLink">Skip to posts</a>
+  <div id="noJsBanner" class="status error" role="alert" hidden>JavaScript is disabled. Some features (search, quick read) won't work. You can still read directly on Substack via the links below.</div>
+  <noscript>
+    <style>
+      #noJsBanner,
+      #noJsBanner[hidden] {
+        display: block !important;
+      }
+    </style>
+  </noscript>
 
-  <div class="backdrop" hidden></div>
-  <section
-    id="poemModal"
-    class="modal"
-    role="dialog"
-    aria-modal="true"
-    aria-hidden="true"
-    aria-labelledby="poemTitle"
-    aria-describedby="poemBody"
-    tabindex="-1"
-    hidden
-  >
-    <div class="modal__shell">
-      <div class="modal__header">
-        <div>
-          <h2 id="poemTitle" class="modal__heading" data-slot="title"></h2>
-          <p id="poemAuthor" class="modal__meta" data-slot="author"></p>
+  <!-- Floating Shapes -->
+  <div class="floating-shapes" aria-hidden="true">
+    <div class="shape accent"></div>
+    <div class="shape accent-2"></div>
+    <div class="shape accent-3"></div>
+  </div>
+
+  <!-- Particles -->
+  <div class="particles" id="particles" aria-hidden="true"></div>
+
+  <!-- Progress Bar -->
+  <div class="progress-bar" id="progressBar" role="progressbar" aria-live="off" aria-valuemin="0" aria-valuemax="100" aria-valuenow="0"></div>
+
+  <div id="appRoot" class="main-content" aria-hidden="false">
+    <!-- HERO -->
+    <section class="hero">
+      <div class="wrap">
+        <div class="hero-content">
+          <div class="brand-section">
+            <a href="./" class="brand-link">
+              <img src="./static/logo-light.svg" alt="Torchborne logo" class="logo-img logo-light" fetchpriority="high" width="64" height="64" />
+              <img src="./static/logo-dark.svg" alt="Torchborne logo" class="logo-img logo-dark" fetchpriority="high" width="64" height="64" />
+              <h1 class="brand-name">Torchborne</h1>
+            </a>
+            <div class="hero-tagline" aria-live="polite">where words carry the flame ✨</div>
+          </div>
+
+          <div class="hero-actions">
+            <button id="themeToggle" class="chip accent" title="Toggle theme" aria-pressed="false">
+              <span id="themeIcon" aria-hidden="true">🌓</span> <span id="themeText">Theme</span>
+            </button>
+            <button id="refreshBtn" class="chip accent" title="Refresh posts">↻ Refresh</button>
+            <button id="randomBtn" class="chip accent" title="Surprise me"><span>🎲</span> Random</button>
+            <button id="aboutBtn" class="btn" title="About" aria-haspopup="dialog" aria-controls="aboutModal">
+              <span>👋</span> About
+            </button>
+            
+            <a class="btn btn-primary" href="/subscribe" rel="noopener">
+              <span>💌</span> Subscribe
+            </a>
+          </div>
+
+          <div class="search-section">
+            <div class="search-wrapper">
+              <svg class="search-icon" width="20" height="20" viewBox="0 0 24 24" fill="none" aria-hidden="true">
+                <path d="M21 21l-4.35-4.35M10.5 18A7.5 7.5 0 1010.5 3a7.5 7.5 0 000 15z" stroke="currentColor" stroke-width="1.5" stroke-linecap="round"/>
+              </svg>
+              <input id="searchInput" type="search" class="search-input" placeholder="Search through poems and musings..." aria-label="Search poems" />
+            </div>
+          </div>
         </div>
       </div>
-      <button type="button" class="modal__close" data-action="close" aria-label="Close poem">✕</button>
-      <article id="poemBody" class="modal__body" data-slot="body"></article>
+    </section>
+
+    <!-- MAIN CONTENT -->
+    <main class="content">
+      <div class="wrap">
+        <div id="statusMessage" class="status" role="status" aria-live="polite">
+          Gathering poems from the digital ether...
+        </div>
+        <section id="postsGrid" class="posts-grid" hidden>
+          
+        </section>
+        <button id="loadMore" class="chip accent" style="display:none; margin: 24px auto 0;" aria-controls="postsGrid">Load older</button>
+      </div>
+    </main>
+
+    <!-- FOOTER -->
+    <footer class="footer">
+      <div class="wrap">
+        <div class="footer-content">
+          <div class="footer-brand">
+            <img src="./static/logo-light.svg" class="footer-logo logo-light" alt="" aria-hidden="true" width="32" height="32">
+            <img src="./static/logo-dark.svg" class="footer-logo logo-dark" alt="" aria-hidden="true" width="32" height="32">
+            <div class="footer-info">
+              <h3>Torchborne</h3>
+              <div class="footerCopyright">© 2025 • Made with ❤️ and pixels</div>
+            </div>
+          </div>
+
+          <nav class="footer-links" aria-label="Footer">
+            <a href="#" id="footerAboutLink" class="pill">About</a>
+            <a href="/subscribe" class="pill">Subscribe</a>
+            <a href="" target="_blank" rel="noopener" class="pill">
+              <svg viewBox="0 0 24 24" width="16" height="16" aria-hidden="true">
+                <path fill="currentColor" d="M3 5h18v2H3V5zm0 4h18v6l-9-3-9 3V9z"/>
+              </svg>
+              Substack
+            </a>
+          </nav>
+        </div>
+      </div>
+    </footer>
+  </div>
+
+  <!-- READING MODAL -->
+  <div id="readingModal" class="modal" aria-hidden="true" role="dialog" aria-modal="true" aria-labelledby="modalTitle" aria-describedby="modalBody" tabindex="-1" hidden>
+    <div class="modal-content">
+      <button class="modal-close" id="readingModalClose" aria-label="Close">✕</button>
+      <div class="modal-header">
+        <h2 class="modal-title" id="modalTitle"></h2>
+        <div class="modal-meta" id="modalMeta"></div>
+        <div class="modal-actions">
+          <button id="prevPost" class="chip accent" title="Previous (←)">← Prev</button>
+          <button id="nextPost" class="chip accent" title="Next (→)">Next →</button>
+        </div>
+      </div>
+      <div class="modal-body" id="modalBody"></div>
     </div>
-  </section>
+  </div>
+
+  <!-- ABOUT MODAL -->
+  <div id="aboutModal" class="modal" aria-hidden="true" role="dialog" aria-modal="true" aria-labelledby="aboutTitle" tabindex="-1" hidden>
+    <div class="modal-content">
+      <button class="modal-close" id="aboutModalClose" aria-label="Close about">✕</button>
+      <div class="modal-header">
+        <div class="about-header">
+          <img class="about-avatar" src="./static/avatar.jpg" alt="Torchborne" onerror="this.src='./static/logo-light.svg'">
+          <div class="about-info">
+            <h2 id="aboutTitle">About Torchborne</h2>
+            <p class="about-tagline">Illuminating poetry, carrying the flame of words ✨</p>
+          </div>
+        </div>
+
+        <div class="about-body">
+          <p>Welcome to my little corner of the internet where I explore the tender spaces between thoughts and feelings. Here you'll find poems, musings, and little sparks of inspiration that dance through everyday moments.</p>
+          <p>I believe poetry lives in the smallest gestures—the way light falls across a page, the pause between heartbeats, the stories we tell ourselves in the quiet hours. This collection gathers my public posts from Substack, made searchable and beautiful for wandering souls like yourself.</p>
+        </div>
+
+        <div class="about-cta">
+          <a class="btn btn-primary" href="/subscribe" rel="noopener">
+            <span>💌</span> Subscribe on Substack
+          </a>
+          <button id="copyEmailBtn" class="btn" data-email="versesvibez@substack.com">
+            <span>📧</span> Copy Email
+          </button>
+        </div>
+
+        <div class="about-links">
+          <a href="" target="_blank" rel="noopener" class="pill">
+            <svg viewBox="0 0 24 24" width="16" height="16" aria-hidden="true">
+              <path fill="currentColor" d="M3 5h18v2H3V5zm0 4h18v6l-9-3-9 3V9z"/>
+            </svg>
+            Substack
+          </a>
+          <a href="mailto:versesvibez@substack.com" class="pill">
+            <svg viewBox="0 0 24 24" width="16" height="16" aria-hidden="true">
+              <path fill="currentColor" d="M20 4H4a2 2 0 00-2 2v12a2 2 0 002 2h16a2 2 0 002-2V6a2 2 0 01-2-2zm0 4l-8 5-8-5V6l8 5 8-5v2z"/>
+            </svg>
+            Email
+          </a>
+          <a href="https://instagram.com/versesvibez" target="_blank" rel="noopener" class="pill">
+            <svg viewBox="0 0 24 24" width="16" height="16" aria-hidden="true">
+              <path fill="currentColor" d="M7 2h10a5 5 0 015 5v10a5 5 0 01-5 5H7a5 5 0 01-5-5V7a5 5 0 015-5zm5 5a5 5 0 100 10 5 5 0 000-10zm6.5-.9a1.1 1.1 0 110 2.2 1.1 1.1 0 010-2.2zM12 9a3 3 0 110 6 3 3 0 010-6z"/>
+            </svg>
+            Instagram
+          </a>
+        </div>
+      </div>
+    </div>
+  </div>
+
+  <!-- DOMPurify for robust sanitization -->
+  <script id="initialPostsData" type="application/json">[]</script>
+  <script
+    src="https://cdn.jsdelivr.net/npm/dompurify@3/dist/purify.min.js"
+    integrity="sha384-OLBgp1GsljhM2TJ+sbHjaiH9txEUvgdDTAzHv2P24donTt6/529l+9Ua0vFImLlb"
+    crossorigin="anonymous"
+    referrerpolicy="no-referrer"
+  ></script>
 
   <script>
-    (function renderPoems() {
-      const poems = [
-        {
-          title: "Midnight Ember",
-          author: "Dami",
-          body: "I keep a lantern by the window\nIts flame remembers every dusk.\nThe city hums in amber verses\nAnd rooftops listen without fuss.\nA hush collects along the railing\nWhile constellations catch their breath.\nI pour the quiet into stanzas\nUntil the ember learns to rest.",
-        },
-        {
-          title: "River Letters",
-          author: "Dami",
-          body: "We fold our wishes into paper\nAnd send them drifting down the stream.\nThe current braids our patient secrets\nWith cedar, tide, and twilight gleam.\nEach ripple smooths the brittle edges\nOf promises we could not say.\nBy dawn the river writes us back\nIn murmured ink of silver spray.",
-        },
-        {
-          title: "Aurora Notes",
-          author: "Dami",
-          body: "Morning inks the frost with color\nAnd hums a vow across the pines.\nThe skyline loosens threads of lilac\nTo stitch our breath with northern lines.\nWe cup the shimmer in our palms\nBefore the rhythm thins to mist.\nThe day begins with whispered chords\nAnd every shadow learns to lift.",
-        },
-      ];
+    // ===== CONFIG =====
+    const RSS_URL        = "https://versesvibez.substack.com/feed";
+    let   WORKER_BASE    = "";
+    const RSS2JSON_KEY   = "";
+    const MAX_ITEMS      = 50;
+    const PUBLIC_BASE    =
+      "https://api.rss2json.com/v1/api.json?"
+      + (RSS2JSON_KEY ? ("api_key=" + encodeURIComponent(RSS2JSON_KEY) + "&") : "")
+      + "count=" + encodeURIComponent(MAX_ITEMS) + "&rss_url=";
+    const FEATURED_EBOOK = {};
+    const TAGLINES = [
+      "where words carry the flame ✨",
+      "poetry for wandering souls ✍️",
+      "verses that glow in the dark 🌙"
+    ];
+    const SUBSTACK_BASE = "https://versesvibez.substack.com";
+    const STATIC_DATA_URL = '/data/posts.json';
 
-      const list = document.querySelector('[data-poem-list]');
-      if (!list) return;
+    function normalizeBase(base) {
+      if (!base) return "";
+      const hasParam = /[?&]rss_url=/.test(base);
+      if (hasParam) return base;
+      const hasQuery = base.includes("?");
+      if (!hasQuery) return base + "?rss_url=";
+      if (!/[&?]$/.test(base)) base += "&";
+      return base + "rss_url=";
+    }
+    WORKER_BASE = normalizeBase(WORKER_BASE);
 
-      const fragment = document.createDocumentFragment();
-      poems.forEach((poem) => {
-        const item = document.createElement('li');
-        item.className = 'poem-card';
+    const CLEAN_SUBSTACK_BASE = SUBSTACK_BASE.replace(/\/$/, '');
 
-        const button = document.createElement('button');
-        button.type = 'button';
-        button.className = 'poem-card__trigger';
-        button.dataset.modalTarget = 'poemModal';
-        button.dataset.poemTitle = poem.title;
-        if (poem.author) button.dataset.poemAuthor = poem.author;
-        button.dataset.poemBody = poem.body;
-        button.setAttribute('aria-label', `Read ${poem.title}`);
-
-        const heading = document.createElement('strong');
-        heading.textContent = poem.title;
-        button.appendChild(heading);
-
-        if (poem.author) {
-          const meta = document.createElement('span');
-          meta.textContent = `by ${poem.author}`;
-          button.appendChild(meta);
-        }
-
-        const excerptLines = poem.body
-          .split('\n')
-          .map((line) => line.trim())
-          .filter(Boolean)
-          .slice(0, 2);
-        if (excerptLines.length) {
-          const excerpt = document.createElement('p');
-          excerpt.className = 'poem-card__excerpt';
-          excerpt.textContent = excerptLines.join(' · ');
-          button.appendChild(excerpt);
-        }
-
-        item.appendChild(button);
-        fragment.appendChild(item);
-      });
-
-      list.appendChild(fragment);
-    })();
-  </script>
-  <script>
-    (function setupPoemModal() {
-      const modal = document.getElementById('poemModal');
-      const backdrop = document.querySelector('.backdrop');
-      if (!modal || !backdrop) return;
-
-      const focusableSelector = [
-        'a[href]',
-        'area[href]',
-        'input:not([disabled])',
-        'select:not([disabled])',
-        'textarea:not([disabled])',
-        'button:not([disabled])',
-        'iframe',
-        '[tabindex]:not([tabindex="-1"])',
-      ].join(', ');
-
-      let activeTrigger = null;
-      let previousOverflow = '';
-
-      const syncHidden = (element, shouldHide) => {
-        if (shouldHide) {
-          if (!element.hasAttribute('hidden')) element.setAttribute('hidden', '');
+    function normalizePost(raw = {}) {
+      if (!raw || typeof raw !== 'object') return null;
+      const slug = typeof raw.slug === 'string' ? raw.slug.trim() : '';
+      const candidates = [raw.link, raw.url, raw.href];
+      let link = '';
+      for (const cand of candidates) {
+        if (typeof cand === 'string' && cand.trim()) { link = cand.trim(); break; }
+      }
+      if (!link && slug) link = `${CLEAN_SUBSTACK_BASE}/p/${slug}`;
+      const pubDate = typeof raw.pubDate === 'string' ? raw.pubDate
+        : typeof raw.pubdate === 'string' ? raw.pubdate
+        : typeof raw.date === 'string' ? raw.date
+        : '';
+      const excerpt = typeof raw.excerpt === 'string' && raw.excerpt.trim()
+        ? raw.excerpt
+        : typeof raw.description === 'string' ? raw.description : '';
+      const content = typeof raw.content === 'string' ? raw.content
+        : typeof raw.html === 'string' ? raw.html
+        : typeof raw.body === 'string' ? raw.body
+        : '';
+      let title = typeof raw.title === 'string' && raw.title.trim() ? raw.title.trim() : '';
+      if (!title) {
+        if (slug) {
+          title = slug
+            .replace(/[-_]+/g, ' ')
+            .replace(/\b\w/g, s => s.toUpperCase());
         } else {
-          element.removeAttribute('hidden');
+          title = 'Untitled';
+        }
+      }
+      const tags = Array.isArray(raw.tags)
+        ? raw.tags.filter(tag => typeof tag === 'string' && tag.trim()).map(tag => tag.trim())
+        : [];
+      return {
+        ...raw,
+        slug,
+        title,
+        link: link || '#',
+        url: link || '#',
+        pubDate: pubDate || '',
+        description: excerpt || '',
+        excerpt: excerpt || '',
+        content,
+        tags,
+      };
+    }
+
+    function normalizePostsList(list) {
+      if (!Array.isArray(list)) return [];
+      return list.map(normalizePost).filter(Boolean);
+    }
+
+    function mergeEntries(base = {}, extra = {}) {
+      const merged = { ...base };
+      for (const key of Object.keys(extra)) {
+        const val = extra[key];
+        if (val == null) continue;
+        if (typeof val === 'string') {
+          if (!val.trim()) continue;
+        } else if (Array.isArray(val)) {
+          if (!val.length) continue;
+        }
+        merged[key] = val;
+      }
+      return merged;
+    }
+
+    function postTimestamp(post) {
+      if (!post) return 0;
+      const dateStr = post.pubDate || post.pubdate || post.date;
+      if (!dateStr) return 0;
+      const ts = Date.parse(dateStr);
+      return Number.isFinite(ts) ? ts : 0;
+    }
+
+    function mergePostLists(existing = [], incoming = []) {
+      const merged = [];
+      const indexByKey = new Map();
+      const add = item => {
+        if (!item) return;
+        const slugKey = typeof item.slug === 'string' && item.slug.trim() ? item.slug.trim().toLowerCase() : '';
+        const guid = typeof item.guid === 'string' && item.guid.trim() ? item.guid.trim() : '';
+        const id = typeof item.id === 'string' && item.id.trim() ? item.id.trim() : '';
+        const linkKey = typeof item.link === 'string' && item.link.trim() ? item.link.trim() : '';
+        const urlKey = typeof item.url === 'string' && item.url.trim() ? item.url.trim() : '';
+        const titleKey = typeof item.title === 'string' && item.title.trim() ? item.title.trim() : '';
+        const key = slugKey || guid || id || linkKey || urlKey || titleKey;
+        if (!key) return;
+        if (indexByKey.has(key)) {
+          const idx = indexByKey.get(key);
+          merged[idx] = mergeEntries(merged[idx], item);
+        } else {
+          indexByKey.set(key, merged.length);
+          merged.push(item);
         }
       };
+      (existing || []).forEach(add);
+      (incoming || []).forEach(add);
+      merged.sort((a, b) => postTimestamp(b) - postTimestamp(a));
+      return merged;
+    }
 
-      const isOpen = () => modal.classList.contains('is-open');
+    const inlineDataElement = document.getElementById('initialPostsData');
+    const INLINE_POSTS = (() => {
+      if (!inlineDataElement) return [];
+      const rawText = (inlineDataElement.textContent || inlineDataElement.innerText || '').trim();
+      if (!rawText) return [];
+      try {
+        const parsed = JSON.parse(rawText);
+        if (Array.isArray(parsed)) return normalizePostsList(parsed);
+        if (parsed && Array.isArray(parsed.posts)) return normalizePostsList(parsed.posts);
+      } catch (err) {
+        console.warn('Inline posts JSON invalid', err);
+      }
+      return [];
+    })();
+    if (inlineDataElement) inlineDataElement.remove();
 
-      const updateModalContent = (trigger) => {
-        const { poemTitle = '', poemAuthor = '', poemBody = '', poemHtml = '' } = trigger.dataset;
-        const titleEl = modal.querySelector('[data-slot="title"]');
-        const authorEl = modal.querySelector('[data-slot="author"]');
-        const bodyEl = modal.querySelector('[data-slot="body"]');
+    // ===== DOM =====
+    const els = {
+      appRoot: document.getElementById('appRoot'),
+      status: document.getElementById('statusMessage'),
+      grid: document.getElementById('postsGrid'),
+      search: document.getElementById('searchInput'),
+      bar: document.getElementById('progressBar'),
+      particles: document.getElementById('particles'),
+      themeToggle: document.getElementById('themeToggle'),
+      themeIcon: document.getElementById('themeIcon'),
+      themeText: document.getElementById('themeText'),
+      refreshBtn: document.getElementById('refreshBtn'),
+      randomBtn: document.getElementById('randomBtn'),
+      loadMore: document.getElementById('loadMore'),
+      aboutBtn: document.getElementById('aboutBtn'),
+      aboutModal: document.getElementById('aboutModal'),
+      aboutClose: document.getElementById('aboutModalClose'),
+      footerAbout: document.getElementById('footerAboutLink'),
+      readingModal: document.getElementById('readingModal'),
+      readingClose: document.getElementById('readingModalClose'),
+      modalTitle: document.getElementById('modalTitle'),
+      modalMeta: document.getElementById('modalMeta'),
+      modalBody: document.getElementById('modalBody'),
+      prev: document.getElementById('prevPost'),
+      next: document.getElementById('nextPost'),
+      copyEmailBtn: document.getElementById('copyEmailBtn'),
+    };
 
-        if (titleEl) titleEl.textContent = poemTitle;
-        if (authorEl) authorEl.textContent = poemAuthor ? `by ${poemAuthor}` : '';
-        if (bodyEl) {
-          if (poemHtml) {
-            bodyEl.innerHTML = poemHtml;
-          } else {
-            bodyEl.textContent = poemBody;
+    // ===== STATE =====
+    let posts = INLINE_POSTS.slice();
+    let iModal = 0;
+    let lastFocus = null;
+    const reduceMotion = window.matchMedia('(prefers-reduced-motion: reduce)').matches;
+
+    // ===== UTIL =====
+    const debounce = (fn, ms=200) => {
+      let t; return (...args) => { clearTimeout(t); t = setTimeout(() => fn(...args), ms); };
+    };
+
+    const escapeHtml = (str='') =>
+      String(str)
+        .replace(/&/g, '&amp;')
+        .replace(/</g, '&lt;')
+        .replace(/>/g, '&gt;')
+        .replace(/"/g, '&quot;')
+        .replace(/'/g, '&#039;');
+
+    // Theme
+    class ThemeManager {
+      init(){
+        const saved = localStorage.getItem('vv-theme');
+        const prefersDark = window.matchMedia('(prefers-color-scheme: dark)').matches;
+        const mode = saved || (prefersDark ? 'dark' : 'light');
+        document.documentElement.setAttribute('data-theme', mode);
+        this.syncButton();
+        this.setThemeColor(mode);
+        els.themeToggle?.addEventListener('click', () => this.toggle(), { passive: true });
+
+        const mql = window.matchMedia('(prefers-color-scheme: dark)');
+        if (mql.addEventListener) {
+          mql.addEventListener('change', e => {
+            if (!localStorage.getItem('vv-theme')) {
+              const m = e.matches ? 'dark' : 'light';
+              document.documentElement.setAttribute('data-theme', m);
+              this.syncButton(); this.setThemeColor(m);
+            }
+          });
+        } else if (mql.addListener) {
+          mql.addListener(e => {
+            if (!localStorage.getItem('vv-theme')) {
+              const m = e.matches ? 'dark' : 'light';
+              document.documentElement.setAttribute('data-theme', m);
+              this.syncButton(); this.setThemeColor(m);
+            }
+          });
+        }
+      }
+      toggle(){
+        const cur = document.documentElement.getAttribute('data-theme') || 'light';
+        const next = cur === 'dark' ? 'light' : 'dark';
+        document.documentElement.setAttribute('data-theme', next);
+        localStorage.setItem('vv-theme', next);
+        els.themeToggle.setAttribute('aria-pressed', String(next === 'dark'));
+        this.bump(els.themeToggle);
+        this.syncButton();
+        this.setThemeColor(next);
+      }
+      syncButton(){
+        const mode = document.documentElement.getAttribute('data-theme') || 'light';
+        if (els.themeIcon) els.themeIcon.textContent = mode === 'dark' ? '☀️' : '🌙';
+        if (els.themeText) els.themeText.textContent = mode === 'dark' ? 'Light mode' : 'Dark mode';
+      }
+      setThemeColor(mode){
+        const meta = document.getElementById('themeColorMeta');
+        if (meta) meta.setAttribute('content', mode === 'dark' ? '#0d0d0d' : '#f59e0b');
+      }
+      bump(el){ el.style.transform = 'scale(0.96)'; setTimeout(() => el.style.transform='', 120); }
+    }
+
+    // Particles
+    class ParticleSystem {
+      constructor(){ this.pool=[]; this.max = reduceMotion ? 0 : 14; this.t=0; this.anim=null; }
+      init(){
+        if (this.max === 0) return;
+        for (let i=0;i<this.max;i++) this.spawn();
+        const step = ts => { this.update(ts); this.anim = requestAnimationFrame(step); };
+        this.anim = requestAnimationFrame(step);
+        document.addEventListener('visibilitychange', () => {
+          if (document.hidden && this.anim) cancelAnimationFrame(this.anim);
+          else if (!reduceMotion) this.anim = requestAnimationFrame(step);
+        }, { passive: true });
+      }
+      spawn(){
+        const p = document.createElement('div');
+        p.className = 'particle';
+        p.style.left = (Math.random()*100) + '%';
+        p.style.top = (100 + Math.random()*20) + 'vh';
+        p.dataset.vy = (-0.1 - Math.random()*0.2).toString();
+        p.dataset.x = (Math.random()*100).toString();
+        els.particles.appendChild(p);
+        this.pool.push(p);
+      }
+      update(ts){
+        this.t = ts * 0.001;
+        for (const p of this.pool){
+          const vy = parseFloat(p.dataset.vy);
+          const top = parseFloat(p.style.top);
+          const nx = parseFloat(p.dataset.x) + Math.sin(this.t + top) * 0.02;
+          p.dataset.x = nx.toString();
+          p.style.transform = `translateX(${nx}vw)`;
+          p.style.top = (top + vy) + 'vh';
+          if (parseFloat(p.style.top) < -10) {
+            p.style.top = (110 + Math.random()*10) + 'vh';
+            p.style.left = (Math.random()*100) + '%';
           }
         }
-      };
+      }
+    }
 
-      const focusFirst = () => {
-        const focusables = modal.querySelectorAll(focusableSelector);
-        const first = focusables.length ? focusables[0] : modal;
-        first.focus({ preventScroll: true });
-      };
-
-      const openModal = (trigger) => {
-        activeTrigger = trigger || document.activeElement || null;
-        previousOverflow = document.body.style.overflow;
-        syncHidden(backdrop, false);
-        syncHidden(modal, false);
-        modal.classList.add('is-open');
-        backdrop.classList.add('is-visible');
-        modal.setAttribute('aria-hidden', 'false');
-        document.body.style.overflow = 'hidden';
-        requestAnimationFrame(focusFirst);
-      };
-
-      const closeModal = () => {
-        if (!isOpen()) return;
-        modal.classList.remove('is-open');
-        backdrop.classList.remove('is-visible');
-        modal.setAttribute('aria-hidden', 'true');
-        syncHidden(backdrop, true);
-        syncHidden(modal, true);
-        document.body.style.overflow = previousOverflow;
-        previousOverflow = '';
-        const trigger = activeTrigger;
-        activeTrigger = null;
-        if (trigger && document.contains(trigger)) {
-          trigger.focus({ preventScroll: true });
+    // Focus trap
+    const Focus = {
+      trap(container){
+        const focusable = container.querySelectorAll('a[href], button:not([disabled]), textarea, input, select, [tabindex]:not([tabindex="-1"])');
+        const first = focusable[0]; const last = focusable[focusable.length - 1];
+        function handle(e){
+          if (e.key !== 'Tab') return;
+          if (e.shiftKey && document.activeElement === first) { e.preventDefault(); last.focus(); }
+          else if (!e.shiftKey && document.activeElement === last) { e.preventDefault(); first.focus(); }
         }
-      };
+        container.addEventListener('keydown', handle);
+        return () => container.removeEventListener('keydown', handle);
+      }
+    };
 
-      document.addEventListener('click', (event) => {
-        const trigger = event.target.closest('[data-modal-target="poemModal"]');
-        if (trigger) {
-          event.preventDefault();
-          updateModalContent(trigger);
-          openModal(trigger);
-          return;
-        }
+    // --- Remove Substack's poetry boilerplate line from RSS HTML ---
+    function stripSubstackBoilerplate(html){
+      const d = document.createElement('div');
+      d.innerHTML = html || '';
+      const isBoilerplate = (t) =>
+        /^text within this block will maintain its original spacing when published/i.test((t||'').trim());
+      d.querySelectorAll('pre, p, div').forEach(el => {
+        if (isBoilerplate(el.textContent || '')) el.remove();
+      });
+      return d.innerHTML;
+    }
 
-        const closeTrigger = event.target.closest('[data-action="close"]');
-        if (closeTrigger && modal.contains(closeTrigger)) {
-          event.preventDefault();
-          closeModal();
-          return;
-        }
-
-        if (event.target === backdrop) {
-          event.preventDefault();
-          closeModal();
+    // Sanitizer using DOMPurify and safe link normalization
+    function sanitize(html){
+      const raw = stripSubstackBoilerplate(html || '');
+      const useDOMPurify = typeof DOMPurify !== 'undefined' && DOMPurify?.sanitize;
+      const cleaned = useDOMPurify
+        ? DOMPurify.sanitize(raw, {
+            RETURN_TRUSTED_TYPE: false,
+            ALLOWED_URI_REGEXP: /^(?:(?:https?|mailto|tel|data:image\/(?:png|gif|jpeg|webp|svg\+xml));?)/i
+          })
+        : raw;
+      const div = document.createElement('div');
+      div.innerHTML = cleaned;
+      // Normalize links (open safely, block javascript:)
+      div.querySelectorAll('a[href]').forEach(a => {
+        const href = (a.getAttribute('href') || '').trim();
+        if (/^javascript:/i.test(href)) a.removeAttribute('href');
+        if (/^https?:\/\//i.test(href)) {
+          a.setAttribute('target','_blank');
+          a.setAttribute('rel','noopener');
         }
       });
-
-      document.addEventListener('keydown', (event) => {
-        if (event.key === 'Escape' && isOpen()) {
-          event.preventDefault();
-          closeModal();
-        }
+      // Remove risky embeds entirely
+      div.querySelectorAll('iframe, object, embed, link, style').forEach(el => el.remove());
+      // Remove inline event handlers
+      div.querySelectorAll('*').forEach(el => {
+        [...el.attributes].forEach(attr => {
+          const n = attr.name.toLowerCase();
+          const v = (attr.value || '').trim().toLowerCase();
+          if (n.startsWith('on') || v.startsWith('javascript:')) el.removeAttribute(attr.name);
+        });
       });
+      div.querySelectorAll('[style]').forEach(el => {
+        const rawStyle = el.getAttribute('style') || '';
 
-      if (modal.classList.contains('is-open')) {
-        modal.setAttribute('aria-hidden', 'false');
-        syncHidden(backdrop, false);
-        syncHidden(modal, false);
-        document.body.style.overflow = 'hidden';
-      } else {
-        modal.setAttribute('aria-hidden', 'true');
-        syncHidden(backdrop, true);
-        syncHidden(modal, true);
+        const cleaned = [];
+        const blockedDirectional = new Set(['top','right','bottom','left','inset']);
+        rawStyle.split(';').forEach(rule => {
+          const trimmed = rule.trim();
+          if (!trimmed) return;
+          const parts = trimmed.split(':');
+          if (parts.length < 2) return;
+          const prop = parts[0].trim();
+          const value = parts.slice(1).join(':').trim();
+          const propLower = prop.toLowerCase();
+          const valueLower = value.toLowerCase();
+
+          cleaned.push(`${prop}: ${value}`);
+        });
+        if (cleaned.length) el.setAttribute('style', cleaned.join('; '));
+        else el.removeAttribute('style');
+      });
+      // Remove substack widgets
+      div.querySelectorAll('.subscription-widget, .subscription-widget-wrap-editor, .button-wrapper').forEach(el => el.remove());
+      return div.innerHTML;
+    }
+
+    // Modals
+    class ModalManager {
+      constructor(){ this.releaseTrap = null; }
+      init(){
+        els.aboutBtn?.addEventListener('click', () => this.openAbout(), { passive: true });
+        els.footerAbout?.addEventListener('click', e => { e.preventDefault(); this.openAbout(); });
+        els.aboutClose?.addEventListener('click', () => this.closeAbout());
+        els.aboutModal?.addEventListener('click', e => { if (e.target === els.aboutModal) this.closeAbout(); });
+
+        els.readingClose?.addEventListener('click', () => this.closeReading());
+        els.readingModal?.addEventListener('click', e => { if (e.target === els.readingModal) this.closeReading(); });
+
+        els.prev?.addEventListener('click', () => this.prev());
+        els.next?.addEventListener('click', () => this.next());
+
+        document.addEventListener('keydown', e => this.key(e));
+        els.modalBody?.addEventListener('scroll', () => this.progress(), { passive: true });
+
+        els.copyEmailBtn?.addEventListener('click', () => this.copy(els.copyEmailBtn?.dataset.email || 'versesvibez@substack.com', els.copyEmailBtn));
+      }
+      lockMain(lock){
+        els.appRoot?.setAttribute('aria-hidden', String(lock));
+        document.body.style.overflow = lock ? 'hidden' : '';
+      }
+      openAbout(){
+        lastFocus = document.activeElement;
+        if (els.aboutModal) els.aboutModal.removeAttribute('hidden');
+        els.aboutModal.classList.add('open');
+        els.aboutModal.setAttribute('aria-hidden','false');
+        this.lockMain(true);
+        this.releaseTrap = Focus.trap(els.aboutModal);
+        els.aboutModal.focus();
+      }
+      closeAbout(){
+        els.aboutModal.classList.remove('open');
+        els.aboutModal.setAttribute('aria-hidden','true');
+        if (els.aboutModal) els.aboutModal.setAttribute('hidden','');
+        this.lockMain(false);
+        this.releaseTrap && this.releaseTrap();
+        lastFocus?.focus();
+      }
+      openReading(post, idx){
+        const isEbook = post.featureType === 'ebook';
+        let meta = '';
+        if (isEbook) {
+          meta = post.feature?.meta || '';
+        } else if (post.pubDate) {
+          meta = new Date(post.pubDate).toLocaleDateString(undefined, { year: 'numeric', month: 'long', day: 'numeric' });
+        }
+
+        els.modalMeta.textContent = meta;
+        els.modalBody.innerHTML = sanitize(post.content || post.description || '');
+        els.modalBody.querySelectorAll('img').forEach(img => { img.loading='lazy'; img.decoding='async'; img.removeAttribute('width'); img.removeAttribute('height'); });
+
+        if (isEbook) {
+          if (post.feature?.note) {
+            const existing = els.modalBody.querySelector('.ebook-note');
+            if (!existing) {
+              const note = document.createElement('p');
+              note.className = 'ebook-note';
+              note.textContent = post.feature.note;
+              els.modalBody.prepend(note);
+            }
+          }
+          const ctaWrap = document.createElement('p');
+          ctaWrap.className = 'ebook-preview-cta';
+          const link = document.createElement('a');
+          link.className = 'btn btn-primary';
+          link.href = post.link;
+          link.target = '_blank';
+          link.rel = 'noopener';
+          const ctaText = (post.feature?.ctaText || 'Read eBook').trim() || 'Read eBook';
+          link.textContent = ctaText;
+          ctaWrap.appendChild(link);
+          els.modalBody.appendChild(ctaWrap);
+        }
+
+        lastFocus = document.activeElement;
+        if (els.readingModal) els.readingModal.removeAttribute('hidden');
+        els.readingModal.classList.add('open');
+        els.readingModal.setAttribute('aria-hidden','false');
+        els.readingModal.dataset.index = idx;
+        iModal = idx;
+        els.bar.style.width = '0%';
+        els.bar.setAttribute('aria-valuenow','0');
+        this.lockMain(true);
+        this.releaseTrap = Focus.trap(els.readingModal);
+        els.readingModal.focus();
+        this.updateNav();
+      }
+      closeReading(){
+        els.readingModal.classList.remove('open');
+        els.readingModal.setAttribute('aria-hidden','true');
+        if (els.readingModal) els.readingModal.setAttribute('hidden','');
+        els.bar.style.width = '0%';
+        els.bar.setAttribute('aria-valuenow','0');
+        els.modalBody.scrollTop = 0;
+        this.lockMain(false);
+        this.releaseTrap && this.releaseTrap();
+        lastFocus?.focus();
+      }
+      key(e){
+        if (e.key === 'Escape') { this.closeAbout(); this.closeReading(); }
+        if (els.readingModal.classList.contains('open')) {
+          if (e.key === 'ArrowRight') this.next();
+          if (e.key === 'ArrowLeft') this.prev();
+        }
+      }
+      next(){ if (iModal < posts.length - 1) this.openReading(posts[iModal + 1], iModal + 1); }
+      prev(){ if (iModal > 0) this.openReading(posts[iModal - 1], iModal - 1); }
+      updateNav(){
+        els.prev.disabled = iModal <= 0;
+        els.next.disabled = iModal >= posts.length - 1;
+      }
+      progress(){
+        const h = els.modalBody.scrollHeight - els.modalBody.clientHeight;
+        const sc = h > 0 ? (els.modalBody.scrollTop / h) * 100 : 0;
+        els.bar.style.width = sc + '%';
+        els.bar.setAttribute('aria-valuenow', String(Math.round(sc)));
+      }
+      async copy(text, btn){
+        const original = btn?.innerHTML;
+        try { await navigator.clipboard.writeText(text);
+          if (btn) { btn.innerHTML = '<span>✓</span> Copied!'; setTimeout(() => btn.innerHTML = original, 1800); }
+        } catch {
+          if (btn) { btn.innerHTML = text; setTimeout(() => btn.innerHTML = original, 2000); }
+        }
+      }
+    }
+
+    // Content
+    class ContentManager {
+      constructor(){
+        this.viewList = [];
+        this.pageSize = 9; // show 9 posts at a time for initial render
+        this.shown = 0;
+        this.featured = this.prepareFeatured();
+        this.inlineConsumed = Boolean(posts.length);
+      }
+      init(){
+        els.search?.addEventListener('input', debounce(() => this.search(), 120));
+        els.refreshBtn?.addEventListener('click', () => this.load(true));
+        els.randomBtn?.addEventListener('click', () => this.random());
+        els.loadMore?.addEventListener('click', () => this.renderNextChunk(false));
+        const initialCards = els.grid ? els.grid.querySelectorAll('[data-post-slug]').length : 0;
+        if (initialCards > this.pageSize) this.pageSize = initialCards;
+        if (posts.length) {
+          this.applyData(posts);
+          this.inlineConsumed = true;
+        }
+        this.load();
       }
 
-      window.poemModalController = {
-        open: openModal,
-        close: closeModal,
-        element: modal,
-      };
-    })();
+      prepareFeatured(){
+        const curated = [
+          {
+            slug: 'embers-of-dawn',
+            title: 'Embers of Dawn',
+            summary: 'A sunrise prayer stitched from soft embers.',
+            tags: ['poem', 'dawn'],
+            link: 'https://versesvibez.substack.com/p/embers-of-dawn',
+            poem: `
+  hush the dark
+    we gather tinder breaths
+and open windows toward the east
+
+    the first light leans in
+  mapping gold across tired knuckles
+`
+          },
+          {
+            slug: 'cartography-of-rest',
+            title: 'Cartography of Rest',
+            summary: 'Tracing the map back to tenderness and home.',
+            tags: ['poem', 'rest'],
+            link: 'https://versesvibez.substack.com/p/cartography-of-rest',
+            poem: `
+we draw the curtains
+and inventory the quiet
+
+  cushions become coordinates
+  for the map back home
+`
+          },
+          {
+            slug: 'blueprint-for-a-firefly-night',
+            title: 'Blueprint for a Firefly Night',
+            summary: 'Instructions for bottling a summer glow.',
+            tags: ['poem', 'night'],
+            link: 'https://versesvibez.substack.com/p/blueprint-for-a-firefly-night',
+            poem: `
+\tmake a sky out of mason jars
+line them on the porch
+
+
+  leave a stanza empty
+
+    so the fireflies can rest
+`
+          }
+        ];
+
+        const stripEdgeNewlines = (poem = '') => {
+          const poemText = poem == null ? '' : String(poem);
+          return poemText
+            .replace(/^(?:\r\n|\r|\n)+/, '')
+            .replace(/(?:\r\n|\r|\n)+$/, '');
+        };
+
+        const renderLine = (line='') => {
+          const match = line.match(/^[ \t]+/);
+          let prefix = '';
+          let rest = line;
+          if (match) {
+            prefix = match[0]
+              .replace(/ /g, '&nbsp;')
+              .replace(/\t/g, '&nbsp;&nbsp;&nbsp;&nbsp;');
+            rest = line.slice(match[0].length);
+          }
+          return prefix + escapeHtml(rest);
+        };
+
+        const poemHtml = (poem='') => {
+          const normalized = stripEdgeNewlines(poem)
+            .replace(/\r\n/g, '\n')
+            .replace(/\r/g, '\n');
+          if (!normalized) return '';
+
+          const lines = normalized.split('\n');
+          const paragraphs = [];
+          let current = [];
+
+          const pushCurrent = () => {
+            paragraphs.push(current);
+            current = [];
+          };
+
+          for (const raw of lines) {
+            if (/^[ \t]*$/.test(raw)) {
+              if (current.length) {
+                pushCurrent();
+              } else {
+                paragraphs.push([]);
+              }
+              continue;
+            }
+            current.push(raw);
+          }
+          if (current.length) pushCurrent();
+
+          if (!paragraphs.length) return '';
+
+          return paragraphs
+            .map(linesArr => {
+              if (!linesArr.length) return '<p><br></p>';
+              const htmlLines = linesArr.map(renderLine).join('<br>');
+              return `<p>${htmlLines}</p>`;
+            })
+            .join('');
+        };
+
+        const poems = curated.map(item => {
+          const html = `<div class="ebook-poem"><h3 class="ebook-poem-title">${escapeHtml(item.title)}</h3>${poemHtml(item.poem)}</div>`;
+          return {
+            ...item,
+            html
+          };
+        });
+
+        const extras = [];
+        if (FEATURED_EBOOK?.url) {
+          const summary = (FEATURED_EBOOK.description || '').trim()
+            || 'Preview selections from the Torchborne poetry eBook.';
+          const preview = poems.map(p => p.html).join('');
+          extras.push({
+            featureType: 'ebook',
+            title: FEATURED_EBOOK.title || 'Torchborne Poetry eBook',
+            link: FEATURED_EBOOK.url,
+            description: summary,
+            content: `<div class="ebook-preview">${preview}</div>`,
+            feature: {
+              tag: FEATURED_EBOOK.tag || 'Featured',
+              meta: FEATURED_EBOOK.meta || '',
+              summary,
+              cover: FEATURED_EBOOK.cover || '',
+              shareText: FEATURED_EBOOK.shareText || 'Share eBook',
+              note: FEATURED_EBOOK.note || '',
+              ctaText: (FEATURED_EBOOK.ctaText || 'Read eBook').trim() || 'Read eBook'
+            }
+          });
+        }
+
+        extras.push(...poems.map(poem => ({
+          featureType: 'poem',
+          title: poem.title,
+          link: poem.link,
+          description: poem.summary,
+          content: poem.html,
+          tags: Array.isArray(poem.tags) ? poem.tags : [],
+          feature: { tags: Array.isArray(poem.tags) ? poem.tags : [] }
+        })));
+
+        return { poems, extras, poemHtml };
+      }
+
+      featuredExtras(){
+        return Array.isArray(this.featured?.extras) ? this.featured.extras : [];
+      }
+
+      }
+
+      textOnly(html){
+        const d=document.createElement('div');
+        d.innerHTML = sanitize(html||'');
+        const t = (d.textContent || d.innerText || '').replace(/\u00a0/g, ' ');
+        return t;
+      }
+
+      firstImage(html){
+        const d=document.createElement('div'); d.innerHTML = sanitize(html||'');
+        const img = d.querySelector('img'); if (img?.src) return img.src;
+        const source = d.querySelector('source[srcset]');
+        if (source){ const first = (source.getAttribute('srcset')||'').split(',')[0]?.trim().split(' ')[0]; if (first) return first; }
+        return null;
+      }
+
+      readTime(txt){
+        const w=(txt.trim().match(/\S+/g)||[]).length;
+        return `${Math.max(1, Math.round(w/180))} min read`;
+      }
+
+      vibes(title=''){
+        const words = (title || '').toLowerCase().match(/[a-z]{4,}/g)||[];
+        return [...new Set(words.slice(0,2))];
+      }
+
+      card(post, idx){
+        const isEbook = post.featureType === 'ebook';
+        const date = post.pubDate ? new Date(post.pubDate) : null;
+        const html = post.content || post.description || '';
+        const txt = this.textOnly(html);
+        const img = this.firstImage(html);
+        const rt = txt ? this.readTime(txt) : '';
+        const feature = post.feature || {};
+        const tags = Array.isArray(post.tags)
+          ? post.tags
+          : Array.isArray(feature.tags)
+            ? feature.tags
+            : this.vibes(post.title);
+        const cover = feature.cover || '';
+        const meta = feature.meta || '';
+        const shareText = (feature.shareText || 'Share eBook').trim() || 'Share eBook';
+        const ctaText = (feature.ctaText || 'Read eBook').trim() || 'Read eBook';
+        const summaryText = (feature.summary || post.description || txt).trim()
+          || (isEbook
+            ? 'Preview selections from the Torchborne poetry eBook.'
+            : 'A Torchborne poem from the archive.');
+
+        const el = document.createElement('article');
+        const palettes = ['accent','accent-2','accent-3'];
+        const accentClass = palettes[idx % palettes.length];
+        el.className = `card ${isEbook ? 'ebook-card accent-3' : accentClass}`;
+        el.style.transitionDelay = `${Math.min(idx,15)*100}ms`;
+        el.setAttribute('aria-label', post.title || (isEbook ? 'Featured eBook' : 'Poem'));
+
+        if (isEbook) {
+          const tag = post.feature?.tag || 'Featured';
+
+          el.innerHTML = `
+            <div class="card-content ebook">
+              <div class="ebook-flag">${escapeHtml(tag)}</div>
+              <div class="ebook-layout">
+                <div class="ebook-cover${cover ? '' : ' placeholder'}">
+                  ${cover ? `<img loading="lazy" decoding="async" src="${cover}" alt="" />` : '<span aria-hidden="true">📘</span>'}
+                </div>
+                <div class="ebook-details">
+                  <h2 class="card-title"><a href="${post.link}" target="_blank" rel="noopener">${escapeHtml(post.title || 'Poetry eBook')}</a></h2>
+                  ${meta ? `<div class="card-meta single">${escapeHtml(meta)}</div>` : ''}
+                  <div class="card-summary">${escapeHtml(summaryText)}</div>
+                  <div class="ebook-actions">
+                    <a class="btn btn-primary" href="${post.link}" target="_blank" rel="noopener">${escapeHtml(ctaText)}</a>
+                    <a href="#" data-share="${encodeURIComponent(post.link)}">${escapeHtml(shareText)}</a>
+                  </div>
+                </div>
+              </div>
+            </div>
+          `;
+        } else {
+          const dateStr = date ? date.toLocaleDateString(undefined,{year:'numeric',month:'short',day:'numeric'}) : '';
+          el.innerHTML = `
+            ${img ? `<div class="card-thumb"><img loading="lazy" decoding="async" src="${img}" alt="" /></div>` : `<div class="card-thumb" aria-hidden="true"></div>`}
+            <div class="card-content">
+              <h2 class="card-title"><a href="${post.link}" target="_blank" rel="noopener">${escapeHtml(post.title || 'Untitled')}</a></h2>
+              <div class="card-meta">
+                ${dateStr ? `<span>📅 ${escapeHtml(dateStr)}</span>` : '' }
+                ${rt ? `<span>⏱️ ${escapeHtml(rt)}</span>` : '' }
+              </div>
+              <div class="card-summary">${escapeHtml(summaryText)}</div>
+              ${tags.length ? `<div class="card-badges">${tags.map(v=>`<span class="badge">${escapeHtml(v)}</span>`).join('')}</div>` : ''}
+              <div class="card-actions">
+                <a href="${post.link}" target="_blank" rel="noopener">Read on Substack →</a>
+                <button type="button" class="linklike" data-quick-read="1" aria-controls="readingModal">Quick read</button>
+                <a href="#" data-share="${encodeURIComponent(post.link)}">Share</a>
+              </div>
+            </div>
+          `;
+        }
+
+        // events
+        el.querySelector('[data-quick-read]')?.addEventListener('click', e => { e.preventDefault(); modal.openReading(post, idx); });
+        const share = el.querySelector('[data-share]');
+        share?.addEventListener('click', async e => {
+          e.preventDefault();
+          const url = post.link, title = post.title || (isEbook ? 'Torchborne Poetry eBook' : 'Poem from Torchborne');
+          try {
+            if (navigator.share) await navigator.share({ title, url });
+            else { await navigator.clipboard.writeText(url); const t = share.textContent; share.textContent='Copied ✓'; setTimeout(()=> share.textContent=t, 1500); }
+          } catch {}
+        });
+
+        const im = el.querySelector('.card-thumb img, .ebook-cover img');
+        if (im) { if (im.complete) im.setAttribute('data-loaded','1'); else im.addEventListener('load', () => im.setAttribute('data-loaded','1')); }
+        return el;
+      }
+
+      skeleton(){
+        const el = document.createElement('div');
+        el.className = 'card-skeleton';
+        el.innerHTML = `
+          <div class="skeleton-thumb shimmer"></div>
+          <div class="skeleton-content">
+            <div class="skeleton-line shimmer"></div>
+            <div class="skeleton-line shimmer"></div>
+            <div class="skeleton-line shimmer short"></div>
+          </div>`;
+        return el;
+      }
+
+      render(list){
+        els.grid.hidden = false;
+        this.viewList = list;
+        els.grid.innerHTML = ""; // reset
+        this.shown = 0;
+        this.renderNextChunk(true);
+        this.finishLoading('');
+      }
+
+      renderNextChunk(reset=false){
+        if (reset) { /* already cleared in render */ }
+        const slice = this.viewList.slice(this.shown, this.shown + this.pageSize);
+        slice.forEach((p) => {
+          const idx = posts.indexOf(p); // ensure modal nav uses global posts index
+          const c = this.card(p, idx >= 0 ? idx : 0);
+          els.grid.appendChild(c);
+          requestAnimationFrame(() => c.classList.add('show'));
+        });
+        this.shown += slice.length;
+        els.loadMore.style.display = this.shown < this.viewList.length ? "inline-flex" : "none";
+      }
+
+      random(){
+        if (!posts.length) return;
+        const idx = Math.floor(Math.random() * posts.length);
+        modal.openReading(posts[idx], idx);
+      }
+
+      search(){
+        const q = (els.search.value || '').trim().toLowerCase();
+        if (!q) { this.render(posts); return; }
+        const filtered = posts.filter(p => {
+          const text = [p.title || '', this.textOnly(p.content || p.description || '')].join(' ').toLowerCase();
+          return text.includes(q);
+        });
+        this.render(filtered);
+      }
+
+      async load(force=false){
+        const hadInitial = posts.length > 0;
+        const showSkeleton = force || !hadInitial;
+        let updated = false;
+        let success = hadInitial;
+
+        if (showSkeleton) {
+          els.grid.setAttribute('aria-busy','true');
+          els.status.className = 'status';
+          els.status.hidden = false;
+          els.status.removeAttribute('role');
+          els.status.textContent = force
+            ? 'Refreshing poems from the digital ether...'
+            : 'Gathering poems from the digital ether...';
+          els.grid.innerHTML = '';
+          for (let i = 0; i < this.pageSize; i++) {
+            els.grid.appendChild(this.skeleton());
+          }
+        } else {
+          this.finishLoading('');
+        }
+
+        if (!this.inlineConsumed && !force && INLINE_POSTS.length) {
+          if (this.applyData(INLINE_POSTS, { forceRender: showSkeleton })) {
+            success = true;
+            updated = true;
+          }
+          this.inlineConsumed = true;
+        }
+
+        const cacheBust = force ? `?_=${Date.now()}` : '';
+        try {
+          const localData = await this.fetchWithTimeout(`${STATIC_DATA_URL}${cacheBust}`, 8000);
+          const localPosts = this.extractPosts(localData);
+          if (this.applyData(localPosts, { forceRender: showSkeleton })) {
+            success = true;
+            updated = true;
+          }
+        } catch (err) {
+          if (err && err.name !== 'AbortError') {
+            console.warn('Local posts unavailable:', err);
+          }
+        }
+
+        if (!success || force) {
+          const worker = WORKER_BASE ? WORKER_BASE + encodeURIComponent(RSS_URL) : null;
+          const publicUrl = PUBLIC_BASE + encodeURIComponent(RSS_URL);
+          const sources = [];
+          if (worker) sources.push(worker + (force ? `&_=${Date.now()}` : ''));
+          sources.push(publicUrl + (force ? `&_=${Date.now()}` : ''));
+          for (const url of sources) {
+            try {
+              const data = await this.fetchWithTimeout(url, 12000);
+              const list = this.extractPosts(data);
+              if (this.applyData(list, { forceRender: showSkeleton })) {
+                success = true;
+                updated = true;
+                break;
+              }
+            } catch (e) {
+              if (e && e.name !== 'AbortError') {
+                console.warn('Feed source failed:', url, e);
+              }
+            }
+          }
+        }
+
+        if (showSkeleton && !updated && posts.length) {
+          this.render(posts);
+        }
+
+        if (!success) {
+          const extras = this.featuredExtras();
+          if (!posts.length && extras.length) {
+            if (this.applyData(extras, { forceRender: true })) {
+              success = true;
+              updated = true;
+              this.finishLoading('Showing curated poems while we reconnect…');
+            }
+          }
+        }
+
+        if (!success) {
+          this.fail();
+          if (!posts.length) {
+            els.grid.innerHTML = '';
+          }
+        } else if (!updated) {
+          this.finishLoading('');
+        }
+
+        els.grid.removeAttribute('aria-busy');
+      }
+
+      async fetchWithTimeout(url, ms=10000){
+        const ctrl = new AbortController();
+        const id = setTimeout(() => ctrl.abort(), ms);
+        try {
+          const res = await fetch(url, { credentials:'omit', cache:'no-store', signal: ctrl.signal });
+          if (!res.ok) throw new Error('HTTP ' + res.status);
+          const text = await res.text();
+          const trimmed = text.trim();
+          if (!trimmed) return null;
+          try {
+            return JSON.parse(trimmed);
+          } catch (err) {
+            throw new Error('Invalid JSON');
+          }
+        } finally {
+          clearTimeout(id);
+        }
+      }
+
+      extractPosts(payload){
+        if (!payload) return [];
+        let list = [];
+        if (Array.isArray(payload)) list = payload;
+        else if (Array.isArray(payload.posts)) list = payload.posts;
+        else if (Array.isArray(payload.items)) list = payload.items;
+        else if (Array.isArray(payload.data)) list = payload.data;
+        return (list || []).map(item => {
+          if (item && !item.content && item["content:encoded"]) {
+            return { ...item, content: item["content:encoded"] };
+          }
+          return item;
+        });
+      }
+
+      applyData(rawList, { forceRender = false } = {}){
+        const normalized = normalizePostsList(rawList).filter(item => {
+          if (!item) return false;
+          const title = (item.title || '').trim();
+          const text = this.textOnly(item.content || item.description || '').trim();
+          if (/coming\s+soon/i.test(title)) return false;
+          return Boolean(title || text);
+        });
+        if (!normalized.length) return false;
+        const merged = mergePostLists(posts, normalized);
+        const limited = (MAX_ITEMS && Number.isFinite(+MAX_ITEMS)) ? merged.slice(0, +MAX_ITEMS) : merged;
+        const changed = limited.length !== posts.length || limited.some((item, idx) => item !== posts[idx]);
+        posts = limited;
+        if (changed || forceRender || !this.viewList.length) {
+          this.render(posts);
+        } else {
+          this.finishLoading('');
+        }
+        return true;
+      }
+
+      finishLoading(message=''){
+        els.status.className = 'status';
+        if (message) {
+          els.status.hidden = false;
+          els.status.removeAttribute('role');
+          els.status.textContent = message;
+        } else {
+          els.status.hidden = true;
+          els.status.removeAttribute('role');
+          els.status.textContent = '';
+        }
+      }
+
+      fail(){
+        els.status.hidden = false;
+        els.status.className = 'status error';
+        els.status.setAttribute('role','alert');
+        els.status.textContent = "Unable to load poems right now. You can read on Substack via the links below.";
+      }
+    }
+
+    // ===== INIT =====
+    const theme = new ThemeManager();
+    const particles = new ParticleSystem();
+    const modal = new ModalManager();
+    const content = new ContentManager();
+
+    document.addEventListener('DOMContentLoaded', () => {
+      theme.init();
+      particles.init();
+      modal.init();
+      content.init();
+      const tag = document.querySelector('.hero-tagline');
+      if (tag) tag.textContent = TAGLINES[Math.floor(Math.random() * TAGLINES.length)];
+      let i = 0;
+      setInterval(() => {
+        i = (i + 1) % TAGLINES.length;
+        tag.textContent = TAGLINES[i];
+      }, 5000);
+      console.log('✨ Torchborne — ready to inspire');
+      
+      // Verify CSS actually loaded; if not, show a helpful status
+      (function ensureCss(){
+        const link = document.getElementById('mainCss');
+        const flag = () => { try { els.status.classList.add('error'); els.status.textContent = 'Styles failed to load. Check your static_base and styles.css URL.'; } catch(e){} };
+        if (link) link.addEventListener('error', flag, { once: true });
+        // After a tick, test a CSS-dependent property
+        setTimeout(() => {
+          const probe = document.createElement('div');
+          probe.className = 'posts-grid';
+          document.body.appendChild(probe);
+          const disp = getComputedStyle(probe).display || '';
+          document.body.removeChild(probe);
+          if (!/grid/i.test(disp)) flag();
+        }, 1200);
+      })();
+    }, { passive: true });
   </script>
 </body>
 </html>

--- a/index.html
+++ b/index.html
@@ -5,6 +5,8 @@
   
   
   
+  
+  
   <meta charset="utf-8" />
   <title>Torchborne</title>
   <meta name="viewport" content="width=device-width, initial-scale=1" />
@@ -111,7 +113,7 @@
               <span>👋</span> About
             </button>
             
-            <a class="btn btn-primary" href="/subscribe" rel="noopener">
+            <a class="btn btn-primary" href="https://versesvibez.substack.com/subscribe" rel="noopener">
               <span>💌</span> Subscribe
             </a>
           </div>
@@ -156,8 +158,8 @@
 
           <nav class="footer-links" aria-label="Footer">
             <a href="#" id="footerAboutLink" class="pill">About</a>
-            <a href="/subscribe" class="pill">Subscribe</a>
-            <a href="" target="_blank" rel="noopener" class="pill">
+            <a href="https://versesvibez.substack.com/subscribe" class="pill">Subscribe</a>
+            <a href="https://versesvibez.substack.com" target="_blank" rel="noopener" class="pill">
               <svg viewBox="0 0 24 24" width="16" height="16" aria-hidden="true">
                 <path fill="currentColor" d="M3 5h18v2H3V5zm0 4h18v6l-9-3-9 3V9z"/>
               </svg>
@@ -204,7 +206,7 @@
         </div>
 
         <div class="about-cta">
-          <a class="btn btn-primary" href="/subscribe" rel="noopener">
+          <a class="btn btn-primary" href="https://versesvibez.substack.com/subscribe" rel="noopener">
             <span>💌</span> Subscribe on Substack
           </a>
           <button id="copyEmailBtn" class="btn" data-email="versesvibez@substack.com">
@@ -213,7 +215,7 @@
         </div>
 
         <div class="about-links">
-          <a href="" target="_blank" rel="noopener" class="pill">
+          <a href="https://versesvibez.substack.com" target="_blank" rel="noopener" class="pill">
             <svg viewBox="0 0 24 24" width="16" height="16" aria-hidden="true">
               <path fill="currentColor" d="M3 5h18v2H3V5zm0 4h18v6l-9-3-9 3V9z"/>
             </svg>

--- a/index.html.j2
+++ b/index.html.j2
@@ -3,6 +3,7 @@
 <head>
   {% set STATIC = static_base or './static/' %}
   {% set STATICPUB = static_public_base or (public_url.rstrip('/') + '/static/') if public_url else STATIC %}
+  {% set POSTS_BASE = public_url.rstrip('/') if public_url else 'https://versesvibez.substack.com' %}
   <meta charset="utf-8" />
   <title>{{ site_title or "Torchborne" }}</title>
   <meta name="viewport" content="width=device-width, initial-scale=1" />
@@ -62,8 +63,14 @@
 </head>
 <body>
   <a href="#postsGrid" class="visually-hidden" id="skipLink">Skip to posts</a>
+  <div id="noJsBanner" class="status error" role="alert" hidden>JavaScript is disabled. Some features (search, quick read) won't work. You can still read directly on Substack via the links below.</div>
   <noscript>
-    <div class="status error" role="alert">JavaScript is disabled. Some features (search, quick read) won't work. You can still read directly on Substack via the links below.</div>
+    <style>
+      #noJsBanner,
+      #noJsBanner[hidden] {
+        display: block !important;
+      }
+    </style>
   </noscript>
 
   <!-- Floating Shapes -->
@@ -127,8 +134,36 @@
     <!-- MAIN CONTENT -->
     <main class="content">
       <div class="wrap">
-        <div id="statusMessage" class="status" role="status" aria-live="polite">Gathering poems from the digital ether...</div>
-        <section id="postsGrid" class="posts-grid" hidden></section>
+        <div id="statusMessage" class="status" role="status" aria-live="polite"{% if posts %} hidden{% endif %}>
+          {% if not posts %}Gathering poems from the digital ether...{% endif %}
+        </div>
+        <section id="postsGrid" class="posts-grid"{% if not posts %} hidden{% endif %}>
+          {% if posts %}
+            {% set accent_classes = ['accent', 'accent-2', 'accent-3'] %}
+            {% for post in posts[:9] %}
+              {% set slug = post.slug or '' %}
+              {% set candidate_url = post.url or post.link %}
+              {% set post_url = candidate_url if candidate_url else (POSTS_BASE ~ '/p/' ~ slug if slug else POSTS_BASE) %}
+              {% set iso_date = post.date or post.pubDate or post.published_at %}
+              {% set display_date = post.date_human or (iso_date[:10] if iso_date else '') %}
+              {% set accent = accent_classes[loop.index0 % (accent_classes | length)] %}
+              {% set card_title = post.title if post.title else (slug.replace('-', ' ') if slug else 'Untitled') %}
+              <article class="card {{ accent }}" data-post-slug="{{ slug }}">
+                <div class="card-thumb" aria-hidden="true"></div>
+                <div class="card-content">
+                  <h2 class="card-title"><a href="{{ post_url }}" target="_blank" rel="noopener">{{ card_title }}</a></h2>
+                  <div class="card-meta">
+                    {% if display_date %}<span>📅 {{ display_date }}</span>{% endif %}
+                  </div>
+                  <div class="card-summary">{{ post.excerpt or post.description or '' }}</div>
+                  <div class="card-actions">
+                    <a href="{{ post_url }}" target="_blank" rel="noopener">Read on Substack →</a>
+                  </div>
+                </div>
+              </article>
+            {% endfor %}
+          {% endif %}
+        </section>
         <button id="loadMore" class="chip accent" style="display:none; margin: 24px auto 0;" aria-controls="postsGrid">Load older</button>
       </div>
     </main>
@@ -162,7 +197,7 @@
   </div>
 
   <!-- READING MODAL -->
-  <div id="readingModal" class="modal" aria-hidden="true" role="dialog" aria-modal="true" aria-labelledby="modalTitle" aria-describedby="modalBody" tabindex="-1">
+  <div id="readingModal" class="modal" aria-hidden="true" role="dialog" aria-modal="true" aria-labelledby="modalTitle" aria-describedby="modalBody" tabindex="-1" hidden>
     <div class="modal-content">
       <button class="modal-close" id="readingModalClose" aria-label="Close">✕</button>
       <div class="modal-header">
@@ -178,7 +213,7 @@
   </div>
 
   <!-- ABOUT MODAL -->
-  <div id="aboutModal" class="modal" aria-hidden="true" role="dialog" aria-modal="true" aria-labelledby="aboutTitle" tabindex="-1">
+  <div id="aboutModal" class="modal" aria-hidden="true" role="dialog" aria-modal="true" aria-labelledby="aboutTitle" tabindex="-1" hidden>
     <div class="modal-content">
       <button class="modal-close" id="aboutModalClose" aria-label="Close about">✕</button>
       <div class="modal-header">
@@ -229,6 +264,7 @@
   </div>
 
   <!-- DOMPurify for robust sanitization -->
+  <script id="initialPostsData" type="application/json">{{ (posts or []) | tojson }}</script>
   <script
     src="https://cdn.jsdelivr.net/npm/dompurify@3/dist/purify.min.js"
     integrity="sha384-OLBgp1GsljhM2TJ+sbHjaiH9txEUvgdDTAzHv2P24donTt6/529l+9Ua0vFImLlb"
@@ -252,6 +288,8 @@
       "poetry for wandering souls ✍️",
       "verses that glow in the dark 🌙"
     ];
+    const SUBSTACK_BASE = {{ POSTS_BASE | tojson }};
+    const STATIC_DATA_URL = '/data/posts.json';
 
     function normalizeBase(base) {
       if (!base) return "";
@@ -263,6 +301,126 @@
       return base + "rss_url=";
     }
     WORKER_BASE = normalizeBase(WORKER_BASE);
+
+    const CLEAN_SUBSTACK_BASE = SUBSTACK_BASE.replace(/\/$/, '');
+
+    function normalizePost(raw = {}) {
+      if (!raw || typeof raw !== 'object') return null;
+      const slug = typeof raw.slug === 'string' ? raw.slug.trim() : '';
+      const candidates = [raw.link, raw.url, raw.href];
+      let link = '';
+      for (const cand of candidates) {
+        if (typeof cand === 'string' && cand.trim()) { link = cand.trim(); break; }
+      }
+      if (!link && slug) link = `${CLEAN_SUBSTACK_BASE}/p/${slug}`;
+      const pubDate = typeof raw.pubDate === 'string' ? raw.pubDate
+        : typeof raw.pubdate === 'string' ? raw.pubdate
+        : typeof raw.date === 'string' ? raw.date
+        : '';
+      const excerpt = typeof raw.excerpt === 'string' && raw.excerpt.trim()
+        ? raw.excerpt
+        : typeof raw.description === 'string' ? raw.description : '';
+      const content = typeof raw.content === 'string' ? raw.content
+        : typeof raw.html === 'string' ? raw.html
+        : typeof raw.body === 'string' ? raw.body
+        : '';
+      let title = typeof raw.title === 'string' && raw.title.trim() ? raw.title.trim() : '';
+      if (!title) {
+        if (slug) {
+          title = slug
+            .replace(/[-_]+/g, ' ')
+            .replace(/\b\w/g, s => s.toUpperCase());
+        } else {
+          title = 'Untitled';
+        }
+      }
+      const tags = Array.isArray(raw.tags)
+        ? raw.tags.filter(tag => typeof tag === 'string' && tag.trim()).map(tag => tag.trim())
+        : [];
+      return {
+        ...raw,
+        slug,
+        title,
+        link: link || '#',
+        url: link || '#',
+        pubDate: pubDate || '',
+        description: excerpt || '',
+        excerpt: excerpt || '',
+        content,
+        tags,
+      };
+    }
+
+    function normalizePostsList(list) {
+      if (!Array.isArray(list)) return [];
+      return list.map(normalizePost).filter(Boolean);
+    }
+
+    function mergeEntries(base = {}, extra = {}) {
+      const merged = { ...base };
+      for (const key of Object.keys(extra)) {
+        const val = extra[key];
+        if (val == null) continue;
+        if (typeof val === 'string') {
+          if (!val.trim()) continue;
+        } else if (Array.isArray(val)) {
+          if (!val.length) continue;
+        }
+        merged[key] = val;
+      }
+      return merged;
+    }
+
+    function postTimestamp(post) {
+      if (!post) return 0;
+      const dateStr = post.pubDate || post.pubdate || post.date;
+      if (!dateStr) return 0;
+      const ts = Date.parse(dateStr);
+      return Number.isFinite(ts) ? ts : 0;
+    }
+
+    function mergePostLists(existing = [], incoming = []) {
+      const merged = [];
+      const indexByKey = new Map();
+      const add = item => {
+        if (!item) return;
+        const slugKey = typeof item.slug === 'string' && item.slug.trim() ? item.slug.trim().toLowerCase() : '';
+        const guid = typeof item.guid === 'string' && item.guid.trim() ? item.guid.trim() : '';
+        const id = typeof item.id === 'string' && item.id.trim() ? item.id.trim() : '';
+        const linkKey = typeof item.link === 'string' && item.link.trim() ? item.link.trim() : '';
+        const urlKey = typeof item.url === 'string' && item.url.trim() ? item.url.trim() : '';
+        const titleKey = typeof item.title === 'string' && item.title.trim() ? item.title.trim() : '';
+        const key = slugKey || guid || id || linkKey || urlKey || titleKey;
+        if (!key) return;
+        if (indexByKey.has(key)) {
+          const idx = indexByKey.get(key);
+          merged[idx] = mergeEntries(merged[idx], item);
+        } else {
+          indexByKey.set(key, merged.length);
+          merged.push(item);
+        }
+      };
+      (existing || []).forEach(add);
+      (incoming || []).forEach(add);
+      merged.sort((a, b) => postTimestamp(b) - postTimestamp(a));
+      return merged;
+    }
+
+    const inlineDataElement = document.getElementById('initialPostsData');
+    const INLINE_POSTS = (() => {
+      if (!inlineDataElement) return [];
+      const rawText = (inlineDataElement.textContent || inlineDataElement.innerText || '').trim();
+      if (!rawText) return [];
+      try {
+        const parsed = JSON.parse(rawText);
+        if (Array.isArray(parsed)) return normalizePostsList(parsed);
+        if (parsed && Array.isArray(parsed.posts)) return normalizePostsList(parsed.posts);
+      } catch (err) {
+        console.warn('Inline posts JSON invalid', err);
+      }
+      return [];
+    })();
+    if (inlineDataElement) inlineDataElement.remove();
 
     // ===== DOM =====
     const els = {
@@ -293,7 +451,7 @@
     };
 
     // ===== STATE =====
-    let posts = [];
+    let posts = INLINE_POSTS.slice();
     let iModal = 0;
     let lastFocus = null;
     const reduceMotion = window.matchMedia('(prefers-reduced-motion: reduce)').matches;
@@ -512,6 +670,7 @@
       }
       openAbout(){
         lastFocus = document.activeElement;
+        if (els.aboutModal) els.aboutModal.removeAttribute('hidden');
         els.aboutModal.classList.add('open');
         els.aboutModal.setAttribute('aria-hidden','false');
         this.lockMain(true);
@@ -521,6 +680,7 @@
       closeAbout(){
         els.aboutModal.classList.remove('open');
         els.aboutModal.setAttribute('aria-hidden','true');
+        if (els.aboutModal) els.aboutModal.setAttribute('hidden','');
         this.lockMain(false);
         this.releaseTrap && this.releaseTrap();
         lastFocus?.focus();
@@ -562,6 +722,7 @@
         }
 
         lastFocus = document.activeElement;
+        if (els.readingModal) els.readingModal.removeAttribute('hidden');
         els.readingModal.classList.add('open');
         els.readingModal.setAttribute('aria-hidden','false');
         els.readingModal.dataset.index = idx;
@@ -576,6 +737,7 @@
       closeReading(){
         els.readingModal.classList.remove('open');
         els.readingModal.setAttribute('aria-hidden','true');
+        if (els.readingModal) els.readingModal.setAttribute('hidden','');
         els.bar.style.width = '0%';
         els.bar.setAttribute('aria-valuenow','0');
         els.modalBody.scrollTop = 0;
@@ -616,15 +778,22 @@
     class ContentManager {
       constructor(){
         this.viewList = [];
-        this.pageSize = 6; // show 6 posts at a time
+        this.pageSize = 9; // show 9 posts at a time for initial render
         this.shown = 0;
         this.featured = this.prepareFeatured();
+        this.inlineConsumed = Boolean(posts.length);
       }
       init(){
         els.search?.addEventListener('input', debounce(() => this.search(), 120));
         els.refreshBtn?.addEventListener('click', () => this.load(true));
         els.randomBtn?.addEventListener('click', () => this.random());
         els.loadMore?.addEventListener('click', () => this.renderNextChunk(false));
+        const initialCards = els.grid ? els.grid.querySelectorAll('[data-post-slug]').length : 0;
+        if (initialCards > this.pageSize) this.pageSize = initialCards;
+        if (posts.length) {
+          this.applyData(posts);
+          this.inlineConsumed = true;
+        }
         this.load();
       }
 
@@ -919,6 +1088,7 @@ line them on the porch
         els.grid.innerHTML = ""; // reset
         this.shown = 0;
         this.renderNextChunk(true);
+        this.finishLoading('');
       }
 
       renderNextChunk(reset=false){
@@ -951,81 +1121,169 @@ line them on the porch
       }
 
       async load(force=false){
-        els.grid.setAttribute('aria-busy','true');
-        els.status.classList.remove('hidden','error');
-        els.status.textContent = "Gathering poems from the digital ether...";
-        els.grid.innerHTML = '';
-        for (let i = 0; i < this.pageSize; i++) {
-          els.grid.appendChild(this.skeleton());
+        const hadInitial = posts.length > 0;
+        const showSkeleton = force || !hadInitial;
+        let updated = false;
+        let success = hadInitial;
+
+        if (showSkeleton) {
+          els.grid.setAttribute('aria-busy','true');
+          els.status.className = 'status';
+          els.status.hidden = false;
+          els.status.removeAttribute('role');
+          els.status.textContent = force
+            ? 'Refreshing poems from the digital ether...'
+            : 'Gathering poems from the digital ether...';
+          els.grid.innerHTML = '';
+          for (let i = 0; i < this.pageSize; i++) {
+            els.grid.appendChild(this.skeleton());
+          }
+        } else {
+          this.finishLoading('');
         }
-        const sources = [];
-        const worker   = WORKER_BASE ? WORKER_BASE + encodeURIComponent(RSS_URL) : null;
-        const publicUrl= PUBLIC_BASE + encodeURIComponent(RSS_URL);
-        if (worker) sources.push(worker + (force ? `&_=${Date.now()}` : ''));
-        sources.push(publicUrl + (force ? `&_=${Date.now()}` : ''));
 
-        for (const url of sources){
-          try {
-            const data = await this.fetchWithTimeout(url, 12000);
-            let raw = Array.isArray(data?.items) ? data.items : [];
-            raw = raw.map(it => {
-              if (!it.content && it["content:encoded"]) it.content = it["content:encoded"];
-              return it;
-            });
-            if (MAX_ITEMS && Number.isFinite(+MAX_ITEMS)) raw = raw.slice(0, +MAX_ITEMS);
+        if (!this.inlineConsumed && !force && INLINE_POSTS.length) {
+          if (this.applyData(INLINE_POSTS, { forceRender: showSkeleton })) {
+            success = true;
+            updated = true;
+          }
+          this.inlineConsumed = true;
+        }
 
-            const valid = raw.filter(p => {
-              const title = (p.title || '').trim();
-              const text = this.textOnly(p.content || p.description || '').trim();
-              if (/coming\s+soon/i.test(title)) return false;
-              return Boolean(title || text);
-            });
-
-
-                .map(v => new Date(v.pubDate || v.pubdate || 0).getTime())
-                .filter(n => !isNaN(n))
-                .sort((a,b)=>b-a)[0];
-              if (newest) {
-                const d = new Date(newest);
-                els.status.textContent = `Last updated ${d.toLocaleString([], { hour: '2-digit', minute: '2-digit', day: '2-digit', month: 'short' })}`;
-              } else {
-                els.status.textContent = "";
-              }
-              this.render(combined);
-              els.grid.removeAttribute('aria-busy');
-              return;
-            } else if (raw.length) {
-
-              posts = combined;
-              els.status.textContent = "";
-              this.render(combined);
-              els.grid.removeAttribute('aria-busy');
-              return;
-            }
-          } catch(e) {
-            console.warn('Feed source failed:', url, e);
+        const cacheBust = force ? `?_=${Date.now()}` : '';
+        try {
+          const localData = await this.fetchWithTimeout(`${STATIC_DATA_URL}${cacheBust}`, 8000);
+          const localPosts = this.extractPosts(localData);
+          if (this.applyData(localPosts, { forceRender: showSkeleton })) {
+            success = true;
+            updated = true;
+          }
+        } catch (err) {
+          if (err && err.name !== 'AbortError') {
+            console.warn('Local posts unavailable:', err);
           }
         }
-        this.fail();
-        const extras = this.featuredExtras();
-        if (extras.length) {
-          posts = extras;
-          els.grid.innerHTML = '';
-          this.render(extras);
-        } else {
-          els.grid.innerHTML = '';
+
+        if (!success || force) {
+          const worker = WORKER_BASE ? WORKER_BASE + encodeURIComponent(RSS_URL) : null;
+          const publicUrl = PUBLIC_BASE + encodeURIComponent(RSS_URL);
+          const sources = [];
+          if (worker) sources.push(worker + (force ? `&_=${Date.now()}` : ''));
+          sources.push(publicUrl + (force ? `&_=${Date.now()}` : ''));
+          for (const url of sources) {
+            try {
+              const data = await this.fetchWithTimeout(url, 12000);
+              const list = this.extractPosts(data);
+              if (this.applyData(list, { forceRender: showSkeleton })) {
+                success = true;
+                updated = true;
+                break;
+              }
+            } catch (e) {
+              if (e && e.name !== 'AbortError') {
+                console.warn('Feed source failed:', url, e);
+              }
+            }
+          }
         }
+
+        if (showSkeleton && !updated && posts.length) {
+          this.render(posts);
+        }
+
+        if (!success) {
+          const extras = this.featuredExtras();
+          if (!posts.length && extras.length) {
+            if (this.applyData(extras, { forceRender: true })) {
+              success = true;
+              updated = true;
+              this.finishLoading('Showing curated poems while we reconnect…');
+            }
+          }
+        }
+
+        if (!success) {
+          this.fail();
+          if (!posts.length) {
+            els.grid.innerHTML = '';
+          }
+        } else if (!updated) {
+          this.finishLoading('');
+        }
+
         els.grid.removeAttribute('aria-busy');
       }
 
-      fetchWithTimeout(url, ms=10000){
-        const ctrl = new AbortController(); const id = setTimeout(()=>ctrl.abort(), ms);
-        return fetch(url, { credentials:'omit', cache:'no-store', signal: ctrl.signal })
-          .then(r => { if (!r.ok) throw new Error('HTTP ' + r.status); return r.json(); })
-          .finally(() => clearTimeout(id));
+      async fetchWithTimeout(url, ms=10000){
+        const ctrl = new AbortController();
+        const id = setTimeout(() => ctrl.abort(), ms);
+        try {
+          const res = await fetch(url, { credentials:'omit', cache:'no-store', signal: ctrl.signal });
+          if (!res.ok) throw new Error('HTTP ' + res.status);
+          const text = await res.text();
+          const trimmed = text.trim();
+          if (!trimmed) return null;
+          try {
+            return JSON.parse(trimmed);
+          } catch (err) {
+            throw new Error('Invalid JSON');
+          }
+        } finally {
+          clearTimeout(id);
+        }
+      }
+
+      extractPosts(payload){
+        if (!payload) return [];
+        let list = [];
+        if (Array.isArray(payload)) list = payload;
+        else if (Array.isArray(payload.posts)) list = payload.posts;
+        else if (Array.isArray(payload.items)) list = payload.items;
+        else if (Array.isArray(payload.data)) list = payload.data;
+        return (list || []).map(item => {
+          if (item && !item.content && item["content:encoded"]) {
+            return { ...item, content: item["content:encoded"] };
+          }
+          return item;
+        });
+      }
+
+      applyData(rawList, { forceRender = false } = {}){
+        const normalized = normalizePostsList(rawList).filter(item => {
+          if (!item) return false;
+          const title = (item.title || '').trim();
+          const text = this.textOnly(item.content || item.description || '').trim();
+          if (/coming\s+soon/i.test(title)) return false;
+          return Boolean(title || text);
+        });
+        if (!normalized.length) return false;
+        const merged = mergePostLists(posts, normalized);
+        const limited = (MAX_ITEMS && Number.isFinite(+MAX_ITEMS)) ? merged.slice(0, +MAX_ITEMS) : merged;
+        const changed = limited.length !== posts.length || limited.some((item, idx) => item !== posts[idx]);
+        posts = limited;
+        if (changed || forceRender || !this.viewList.length) {
+          this.render(posts);
+        } else {
+          this.finishLoading('');
+        }
+        return true;
+      }
+
+      finishLoading(message=''){
+        els.status.className = 'status';
+        if (message) {
+          els.status.hidden = false;
+          els.status.removeAttribute('role');
+          els.status.textContent = message;
+        } else {
+          els.status.hidden = true;
+          els.status.removeAttribute('role');
+          els.status.textContent = '';
+        }
       }
 
       fail(){
+        els.status.hidden = false;
         els.status.className = 'status error';
         els.status.setAttribute('role','alert');
         els.status.textContent = "Unable to load poems right now. You can read on Substack via the links below.";

--- a/index.html.j2
+++ b/index.html.j2
@@ -2,8 +2,10 @@
 <html lang="en" data-theme="light">
 <head>
   {% set STATIC = static_base or './static/' %}
-  {% set STATICPUB = static_public_base or (public_url.rstrip('/') + '/static/') if public_url else STATIC %}
-  {% set POSTS_BASE = public_url.rstrip('/') if public_url else 'https://versesvibez.substack.com' %}
+  {% set PUBLIC_URL = (public_url or '').rstrip('/') %}
+  {% set STATICPUB = static_public_base or (PUBLIC_URL + '/static/') if PUBLIC_URL else STATIC %}
+  {% set POSTS_BASE = PUBLIC_URL if PUBLIC_URL else 'https://versesvibez.substack.com' %}
+  {% set SUBSCRIBE_URL = (PUBLIC_URL + '/subscribe') if PUBLIC_URL else (POSTS_BASE + '/subscribe') %}
   <meta charset="utf-8" />
   <title>{{ site_title or "Torchborne" }}</title>
   <meta name="viewport" content="width=device-width, initial-scale=1" />
@@ -11,7 +13,7 @@
   <meta name="description" content="Poetry & musings by Dami." />
   <meta name="color-scheme" content="light dark" />
   <meta id="themeColorMeta" name="theme-color" content="#f59e0b" />
-  <link rel="canonical" href="{{ public_url or '' }}" />
+  <link rel="canonical" href="{{ PUBLIC_URL or '' }}" />
 
   <!-- Fonts -->
   <link rel="preconnect" href="https://fonts.googleapis.com" crossorigin>
@@ -31,7 +33,7 @@
   <meta property="og:title" content="{{ site_title or 'Torchborne' }}" />
   <meta property="og:description" content="Poetry & musings by Dami." />
   <meta property="og:type" content="website" />
-  <meta property="og:url" content="{{ public_url or '' }}" />
+  <meta property="og:url" content="{{ PUBLIC_URL or '' }}" />
   <meta property="og:image" content="{{ STATICPUB ~ 'logo-light.svg' }}" />
   <meta property="og:site_name" content="{{ site_title or 'Torchborne' }}" />
   <meta name="twitter:card" content="summary_large_image">
@@ -114,7 +116,7 @@
 
             </a>
             {% endif %}
-            <a class="btn btn-primary" href="{{ public_url.rstrip('/') + '/subscribe' }}" rel="noopener">
+            <a class="btn btn-primary" href="{{ SUBSCRIBE_URL }}" rel="noopener">
               <span>💌</span> Subscribe
             </a>
           </div>
@@ -183,8 +185,8 @@
 
           <nav class="footer-links" aria-label="Footer">
             <a href="#" id="footerAboutLink" class="pill">About</a>
-            <a href="{{ public_url.rstrip('/') + '/subscribe' }}" class="pill">Subscribe</a>
-            <a href="{{ public_url.rstrip('/') }}" target="_blank" rel="noopener" class="pill">
+            <a href="{{ SUBSCRIBE_URL }}" class="pill">Subscribe</a>
+            <a href="{{ POSTS_BASE }}" target="_blank" rel="noopener" class="pill">
               <svg viewBox="0 0 24 24" width="16" height="16" aria-hidden="true">
                 <path fill="currentColor" d="M3 5h18v2H3V5zm0 4h18v6l-9-3-9 3V9z"/>
               </svg>
@@ -231,7 +233,7 @@
         </div>
 
         <div class="about-cta">
-          <a class="btn btn-primary" href="{{ public_url.rstrip('/') + '/subscribe' }}" rel="noopener">
+          <a class="btn btn-primary" href="{{ SUBSCRIBE_URL }}" rel="noopener">
             <span>💌</span> Subscribe on Substack
           </a>
           <button id="copyEmailBtn" class="btn" data-email="versesvibez@substack.com">
@@ -240,7 +242,7 @@
         </div>
 
         <div class="about-links">
-          <a href="{{ public_url.rstrip('/') }}" target="_blank" rel="noopener" class="pill">
+          <a href="{{ POSTS_BASE }}" target="_blank" rel="noopener" class="pill">
             <svg viewBox="0 0 24 24" width="16" height="16" aria-hidden="true">
               <path fill="currentColor" d="M3 5h18v2H3V5zm0 4h18v6l-9-3-9 3V9z"/>
             </svg>

--- a/index.html.j2
+++ b/index.html.j2
@@ -291,7 +291,7 @@
       "verses that glow in the dark 🌙"
     ];
     const SUBSTACK_BASE = {{ POSTS_BASE | tojson }};
-    const STATIC_DATA_URL = '/data/posts.json';
+    const STATIC_DATA_URL = './data/posts.json';
 
     function normalizeBase(base) {
       if (!base) return "";

--- a/scripts/render_index.py
+++ b/scripts/render_index.py
@@ -1,0 +1,137 @@
+#!/usr/bin/env python3
+"""Render index.html from the Jinja2 template."""
+
+from __future__ import annotations
+
+import json
+from datetime import datetime, timezone
+from pathlib import Path
+from typing import Iterable, List, Mapping, MutableMapping, Optional
+
+from jinja2 import Environment, FileSystemLoader, select_autoescape
+
+
+REPO_ROOT = Path(__file__).resolve().parent.parent
+TEMPLATE_NAME = "index.html.j2"
+DATA_PATH = REPO_ROOT / "data" / "posts.json"
+OUTPUT_PATH = REPO_ROOT / "index.html"
+AUTOGEN_BANNER = "<!-- AUTO-GENERATED from index.html.j2. Edit the .j2 file. -->\n"
+
+
+DateInput = Optional[str]
+Post = MutableMapping[str, object]
+
+
+def load_posts() -> List[Post]:
+    if not DATA_PATH.exists():
+        return []
+
+    try:
+        with DATA_PATH.open("r", encoding="utf-8") as handle:
+            payload = json.load(handle)
+    except (OSError, json.JSONDecodeError):
+        return []
+
+    posts: Iterable[Post]
+    if isinstance(payload, list):
+        posts = payload  # type: ignore[assignment]
+    elif isinstance(payload, Mapping):
+        for key in ("posts", "items", "data"):
+            value = payload.get(key)
+            if isinstance(value, list):
+                posts = value  # type: ignore[assignment]
+                break
+        else:
+            posts = []
+    else:
+        posts = []
+
+    # Ensure we have a mutable copy per post for further augmentation.
+    return [dict(post) for post in posts]
+
+
+def parse_date(value: DateInput) -> Optional[datetime]:
+    if not value or not isinstance(value, str):
+        return None
+
+    candidate = value.strip()
+    if not candidate:
+        return None
+
+    # Attempt ISO-8601 parsing with optional trailing Z.
+    iso_candidate = candidate
+    if iso_candidate.endswith("Z"):
+        iso_candidate = iso_candidate[:-1] + "+00:00"
+    try:
+        return datetime.fromisoformat(iso_candidate)
+    except ValueError:
+        pass
+
+    # Try a few common feed formats.
+    date_formats = (
+        "%a, %d %b %Y %H:%M:%S %z",  # RSS/Atom
+        "%Y-%m-%d %H:%M:%S%z",
+        "%Y-%m-%d %H:%M:%S",
+        "%Y-%m-%d",
+        "%Y/%m/%d",
+        "%m/%d/%Y",
+    )
+    for fmt in date_formats:
+        try:
+            return datetime.strptime(candidate, fmt)
+        except ValueError:
+            continue
+
+    return None
+
+
+def decorate_posts(posts: List[Post]) -> None:
+    for post in posts:
+        date_value = None
+        for key in ("date", "pubDate", "published_at", "pubdate"):
+            raw = post.get(key)
+            if isinstance(raw, str) and raw.strip():
+                date_value = raw
+                break
+        dt = parse_date(date_value)
+        if dt is not None:
+            sort_dt = dt.astimezone(timezone.utc) if dt.tzinfo else dt.replace(tzinfo=timezone.utc)
+            post["_sort_ts"] = sort_dt.timestamp()
+            post["date_human"] = sort_dt.strftime("%b %d, %Y")
+        else:
+            post["_sort_ts"] = float("-inf")
+            post["date_human"] = ""
+
+    posts.sort(key=lambda item: item.get("_sort_ts", float("-inf")), reverse=True)
+    for post in posts:
+        post.pop("_sort_ts", None)
+
+
+
+def render(posts: List[Post]) -> str:
+    env = Environment(
+        loader=FileSystemLoader(str(REPO_ROOT)),
+        autoescape=select_autoescape(["html", "xml"]),
+    )
+    template = env.get_template(TEMPLATE_NAME)
+    return template.render(
+        posts=posts,
+        generated_at=datetime.now(timezone.utc),
+        public_url="",
+        feed_url="https://versesvibez.substack.com/feed",
+        static_base="./static/",
+        static_public_base=None,
+        featured_ebook=None,
+    )
+
+
+
+def main() -> None:
+    posts = load_posts()
+    decorate_posts(posts)
+    html = render(posts)
+    OUTPUT_PATH.write_text(AUTOGEN_BANNER + html, encoding="utf-8")
+
+
+if __name__ == "__main__":
+    main()


### PR DESCRIPTION
## Summary
- render the first nine poems directly in the template so the homepage has meaningful content without JavaScript
- embed the full posts payload as inline JSON and update the client script to hydrate from it, fall back to `/data/posts.json`, and gracefully handle bad/missing sources
- tweak UI affordances by hiding the no-JS banner and modals until needed
- add `scripts/render_index.py` to build `index.html` from the Jinja2 template and enrich posts with human-readable dates
- ensure the render step sorts posts by publish date so server-rendered cards show the latest entries with their human-friendly timestamps

## Testing
- pytest
- python scripts/render_index.py

------
https://chatgpt.com/codex/tasks/task_e_68cd1e95a6fc832998f8c4ca1fe21291