### PR TITLE
Fix ContentManager constructor duplication

### DIFF
--- a/public/js/main.js
+++ b/public/js/main.js
@@ -76,8 +76,14 @@
 
   // Content manager (adapted, minimal): builds cards and loads posts from static/proxy sources
   class ContentManager {
-    constructor(){ this.posts = []; this.pageSize = 6; this.shown = 0; this.viewList = []; this.inlineConsumed = false; }
-    constructor(){ this.posts = []; this.pageSize = 6; this.shown = 0; this.viewList = []; this.inlineConsumed = false; this.currentIndex = -1; }
+    constructor(){
+      this.posts = [];
+      this.pageSize = 6;
+      this.shown = 0;
+      this.viewList = [];
+      this.inlineConsumed = false;
+      this.currentIndex = -1;
+    }
     init(){ els.searchInput = getEl('searchInput');
       // refresh and random
       const refresh = getEl('refreshBtn'); if (refresh) refresh.addEventListener('click', ()=> this.load(true));


### PR DESCRIPTION
## Summary
- replace the duplicate ContentManager constructors with a single initializer so the client script can execute

## Testing
- npm test

------
https://chatgpt.com/codex/tasks/task_e_68f75fef68dc8329b0cf0fd29fab442e